### PR TITLE
Only Retain Unique Enumerated Tautomers

### DIFF
--- a/nagl/cli/prepare/enumerate.py
+++ b/nagl/cli/prepare/enumerate.py
@@ -74,6 +74,7 @@ def enumerate_cli(
     print(" - Enumerating tautomers")
 
     output_molecule_stream = oechem.oemolostream(output_path)
+    unique_molecules = set()
 
     with capture_oe_warnings():
 
@@ -92,6 +93,19 @@ def enumerate_cli(
 
                 for oe_molecule in oe_molecules:
 
+                    smiles_options = (
+                        oechem.OESMILESFlag_Canonical
+                        | oechem.OESMILESFlag_AtomStereo
+                        | oechem.OESMILESFlag_BondStereo
+                        | oechem.OESMILESFlag_Hydrogens
+                    )
+
+                    smiles = oechem.OECreateSmiString(oe_molecule, smiles_options)
+
+                    if smiles in unique_molecules:
+                        continue
+
                     oechem.OEWriteMolecule(
                         output_molecule_stream, oechem.OEMol(oe_molecule)
                     )
+                    unique_molecules.add(smiles)

--- a/nagl/tests/cli/prepare/test_enumerate.py
+++ b/nagl/tests/cli/prepare/test_enumerate.py
@@ -9,7 +9,12 @@ from nagl.cli.prepare.enumerate import enumerate_cli
 def test_enumerate_cli(methane: Molecule, runner):
 
     # Create an SDF file to enumerate.
-    Molecule.from_smiles(r"C/C=C(/C)\O").to_file("molecules.sdf", "sdf")
+    buteneol = Molecule.from_smiles(r"C/C=C(/C)\O")
+
+    output_stream = oechem.oemolostream("molecules.sdf")
+    oechem.OEWriteMolecule(output_stream, buteneol.to_openeye())
+    oechem.OEWriteMolecule(output_stream, buteneol.to_openeye())
+    output_stream.close()
 
     arguments = [
         "--input",


### PR DESCRIPTION
## Description
This PR updates the `enumerate` CLI to only save out unique tautomers.

## Status
- [X] Ready to go