### PR TITLE
Add Basic provenance to Labelled Molecule Store

### DIFF
--- a/nagl/tests/utilities/test_provenance.py
+++ b/nagl/tests/utilities/test_provenance.py
@@ -1,0 +1,34 @@
+import pkg_resources
+import pytest
+
+from nagl.utilities.provenance import (
+    _get_ambertools_version,
+    _get_optional_dependency_version,
+    get_labelling_software_provenance,
+)
+
+
+def test_get_optional_dependency_version():
+    assert _get_optional_dependency_version("my_fake_package") is None
+
+
+def test_get_ambertools_version():
+
+    pytest.importorskip("parmed")
+
+    version = _get_ambertools_version()
+    assert version is not None and isinstance(version, str)
+
+
+def test_get_ambertools_version_missing(monkeypatch):
+    def get_distribution(*_):
+        raise pkg_resources.DistributionNotFound("AmberTools")
+
+    monkeypatch.setattr(pkg_resources, "get_distribution", get_distribution)
+
+    version = _get_ambertools_version()
+    assert version is None
+
+
+def test_get_labelling_software_provenance():
+    assert "nagl" in get_labelling_software_provenance()

--- a/nagl/utilities/provenance.py
+++ b/nagl/utilities/provenance.py
@@ -1,0 +1,52 @@
+import importlib
+from typing import Dict, Optional
+
+import pkg_resources
+
+import nagl
+
+
+def _get_optional_dependency_version(import_path: str) -> Optional[str]:
+    """Attempts to retrieve the version of an optional dependency
+
+    Args:
+        import_path: The import path of the dependency.
+
+    Returns:
+        The version of the dependency if it can be imported, otherwise none.
+    """
+
+    try:
+        dependency = importlib.import_module(import_path)
+        # noinspection PyUnresolvedReferences
+        return dependency.__version__
+    except ImportError:
+        return None
+
+
+def _get_ambertools_version() -> Optional[str]:
+
+    try:
+        distribution = pkg_resources.get_distribution("AmberTools")
+        return distribution.version
+    except pkg_resources.DistributionNotFound:
+        return None
+
+
+def get_labelling_software_provenance() -> Dict[str, str]:
+    """Returns the versions of the core dependencies used when labelling a set of
+    molecules."""
+
+    software_provenance = {
+        "nagl": nagl.__version__,
+        "openff-toolkit": _get_optional_dependency_version("openff.toolkit"),
+        "openeye": _get_optional_dependency_version("openeye"),
+        "rdkit": _get_optional_dependency_version("rdkit"),
+        "ambertools": _get_ambertools_version(),
+    }
+
+    return {
+        package_name: version
+        for package_name, version in software_provenance.items()
+        if version is not None
+    }


### PR DESCRIPTION
## Description
This PR adds basic provenance information when to the molecule store created by running the label CLI.

## Status
- [X] Ready to go