### PR TITLE
Update the CI to use the C-F openff-toolkit package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,18 +38,6 @@ jobs:
         auto-activate-base: false
         show-channel-urls: true
 
-    - name: Install the OpenFF Toolkit (pre 0.9.1 release)
-      shell: bash -l {0}
-      run: |
-        conda install --yes --only-deps -c conda-forge openff-toolkit-base
-        conda install --yes -c conda-forge rdkit ambertools
-
-        git clone https://github.com/openforcefield/openff-toolkit.git
-
-        cd openff-toolkit
-        python setup.py develop
-        cd ..
-
     - name: Install Package
       shell: bash -l {0}
       run: |

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -17,16 +17,15 @@ dependencies:
   - dgl
   - tqdm
 
+    # Molecule loading and processing.
+  - openff-toolkit >=0.9.1
+
     # SQL based molecule storage.
   - sqlalchemy
   - sqlite
-  - rdkit
-
-    # Molecule loading and processing.
-  # - openff-toolkit
 
     # Distributed molecule processing / labelling.
-  - distributed
+  - distributed <=2.30.1
   - dask-jobqueue
 
     # Python < 3.7


### PR DESCRIPTION
## Description
This PR updates the CI to use the C-F `openff-toolkit` package now that 0.9.1 is released which contains the toolkit independent ELF implementations and API points.

## Status
- [X] Ready to go