### PR TITLE
Temporary fix guessing stereochemistry of pyramidal N

### DIFF
--- a/nagl/utilities/smiles.py
+++ b/nagl/utilities/smiles.py
@@ -44,10 +44,12 @@ def smiles_to_molecule(smiles: str, guess_stereochemistry: bool = False) -> "Mol
             undefined_only=True, max_isomers=1
         )
 
-        if len(stereoisomers) == 0:
-            raise
-
-        molecule = stereoisomers[0]
+        if len(stereoisomers) > 0:
+            # We would ideally raise an exception here if the number of stereoisomers
+            # is zero, however due to the way that the OFF toolkit perceives pyramidal
+            # nitrogen stereocenters these would show up as undefined stereochemistry
+            # but have no enumerated stereoisomers.
+            molecule = stereoisomers[0]
 
     return molecule
 


### PR DESCRIPTION
## Description
This PR patches any issue whereby the OpenFF toolkit currently raises an exception for unidentified stereochemistry when loading molecules with pyramidal nitrogens using the OE backend, but  (correctly) does not return any stereoisomers when enumerating undefined stereochemistry.

This issue is tracked on the OpenFF issue tracker here: https://github.com/openforcefield/openff-toolkit/issues/725.

## Status
- [X] Ready to go