### PR TITLE
Adds data set from molecule store function

### DIFF
--- a/nagl/tests/dataset/test_dataset.py
+++ b/nagl/tests/dataset/test_dataset.py
@@ -1,4 +1,7 @@
+import os
+
 import numpy
+import pytest
 import torch
 from openff.toolkit.topology import Molecule
 from simtk import unit
@@ -9,6 +12,13 @@ from nagl.dataset.dataset import (
     molecule_to_graph,
 )
 from nagl.dataset.features import AtomConnectivity, BondIsInRing
+from nagl.storage.storage import (
+    ConformerRecord,
+    MoleculeRecord,
+    MoleculeStore,
+    PartialChargeSet,
+    WibergBondOrderSet,
+)
 
 
 def label_function(molecule: Molecule):
@@ -73,6 +83,78 @@ def test_data_set_from_molecules(methane):
     label = labels["formal_charges"]
 
     assert label.numpy().shape == (5,)
+
+
+@pytest.mark.parametrize(
+    "partial_charge_method, bond_order_method",
+    [("am1", None), (None, "am1"), ("am1", "am1")],
+)
+def test_labelled_molecule_to_dict(methane, partial_charge_method, bond_order_method):
+
+    expected_charges = numpy.arange(methane.n_atoms)
+    expected_orders = numpy.arange(methane.n_bonds)
+
+    methane.partial_charges = expected_charges * unit.elementary_charge
+
+    for i, bond in enumerate(methane.bonds):
+        bond.fractional_bond_order = expected_orders[i]
+
+    labels = MoleculeGraphDataset._labelled_molecule_to_dict(
+        methane, partial_charge_method, bond_order_method
+    )
+
+    if partial_charge_method is not None:
+        assert "am1-charges" in labels
+        assert numpy.allclose(expected_charges, labels["am1-charges"])
+    else:
+        assert "am1-charges" not in labels
+
+    if bond_order_method is not None:
+        assert "am1-wbo" in labels
+        assert numpy.allclose(expected_orders, labels["am1-wbo"])
+    else:
+        assert "am1-wbo" not in labels
+
+
+def test_data_set_from_molecule_stores(tmpdir):
+
+    molecule_store = MoleculeStore(os.path.join(tmpdir, "store.sqlite"))
+    molecule_store.store(
+        MoleculeRecord(
+            smiles="[Cl:1]-[H:2]",
+            conformers=[
+                ConformerRecord(
+                    coordinates=numpy.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+                    partial_charges=[
+                        PartialChargeSet(method="am1", values=[0.1, -0.1])
+                    ],
+                    bond_orders=[
+                        WibergBondOrderSet(method="am1", values=[(0, 1, 1.1)])
+                    ],
+                )
+            ],
+        )
+    )
+
+    data_set = MoleculeGraphDataset.from_molecule_stores(
+        molecule_store, "am1", "am1", [AtomConnectivity()], [BondIsInRing()]
+    )
+
+    assert len(data_set) == 1
+    assert data_set.n_features == 4
+
+    molecule_graph, features, labels = data_set[0]
+
+    assert molecule_graph is not None
+    assert len(molecule_graph) == 2
+
+    assert features.numpy().shape == (2, 4)
+
+    assert "am1-charges" in labels
+    assert labels["am1-charges"].numpy().shape == (2,)
+
+    assert "am1-wbo" in labels
+    assert labels["am1-wbo"].numpy().shape == (1,)
 
 
 def test_data_set_loader():


### PR DESCRIPTION
## Description
This PR adds a new `MoleculeGraphDataset.from_molecule_stores` class method which can create a data set from multiple molecule stores.

This method does not currently check if there is duplicate data in the provided stores.

## Status
- [X] Ready to go