### PR TITLE
Simplify the molecule DB store

### DIFF
--- a/nagl/cli/label/label.py
+++ b/nagl/cli/label/label.py
@@ -1,4 +1,5 @@
 import math
+import traceback
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
@@ -111,7 +112,7 @@ def label_molecule_batch(
         except (BaseException, Exception) as e:
             error = (
                 f"Failed to process {molecule.to_smiles(explicit_hydrogens=False)}: "
-                f"{str(e)}"
+                f"{traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)}"
             )
 
         molecule_records.append((molecule_record, error))
@@ -306,7 +307,11 @@ def label_cli(
                     if molecule_record is not None and error is None:
                         storage.store(molecule_record)
                 except (BaseException, Exception) as e:
-                    error = str(e)
+
+                    formatted_traceback = traceback.format_exception(
+                        etype=type(e), value=e, tb=e.__traceback__
+                    )
+                    error = f"Could not store record: {formatted_traceback}"
 
                 if error is not None:
 

--- a/nagl/datasets.py
+++ b/nagl/datasets.py
@@ -210,24 +210,16 @@ class DGLMoleculeDataset(Dataset):
 
         for record in tqdm(stored_records):
 
-            molecule: Molecule = Molecule.from_mapped_smiles(record.smiles)
+            molecule: Molecule = Molecule.from_mapped_smiles(
+                record.smiles, allow_undefined_stereo=True
+            )
 
             if partial_charge_method is not None:
 
-                average_partial_charges = (
-                    numpy.mean(
-                        [
-                            charge_set.values
-                            for conformer in record.conformers
-                            for charge_set in conformer.partial_charges
-                            if charge_set.method == partial_charge_method
-                        ],
-                        axis=0,
-                    )
+                molecule.partial_charges = (
+                    numpy.array(record.average_partial_charges(partial_charge_method))
                     * unit.elementary_charge
                 )
-
-                molecule.partial_charges = average_partial_charges
 
             if bond_order_method is not None:
 

--- a/nagl/storage/db.py
+++ b/nagl/storage/db.py
@@ -1,32 +1,10 @@
-from sqlalchemy import Column, Float, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy import Column, ForeignKey, Integer, PickleType, String, UniqueConstraint
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
 DBBase = declarative_base()
 
 DB_VERSION = 1
-
-
-class DBCoordinate(DBBase):
-
-    __tablename__ = "coordinates"
-
-    id = Column(Integer, primary_key=True, index=True)
-    parent_id = Column(Integer, ForeignKey("conformers.id"), nullable=False)
-
-    x = Column(Float, nullable=False)
-    y = Column(Float, nullable=False)
-    z = Column(Float, nullable=False)
-
-
-class DBPartialCharge(DBBase):
-
-    __tablename__ = "partial_charges"
-
-    id = Column(Integer, primary_key=True, index=True)
-    parent_id = Column(Integer, ForeignKey("partial_charge_sets.id"), nullable=False)
-
-    value = Column(Float, nullable=False)
 
 
 class DBPartialChargeSet(DBBase):
@@ -37,25 +15,11 @@ class DBPartialChargeSet(DBBase):
     parent_id = Column(Integer, ForeignKey("conformers.id"), nullable=False)
 
     method = Column(String(10), nullable=False)
-
-    values = relationship("DBPartialCharge")
+    values = Column(PickleType, nullable=False)
 
     __table_args__ = (
         UniqueConstraint("parent_id", "method", name="_pc_parent_method_uc"),
     )
-
-
-class DBWibergBondOrder(DBBase):
-
-    __tablename__ = "wiberg_bond_orders"
-
-    id = Column(Integer, primary_key=True, index=True)
-    parent_id = Column(Integer, ForeignKey("wiberg_bond_order_sets.id"), nullable=False)
-
-    index_a = Column(Integer, nullable=False)
-    index_b = Column(Integer, nullable=False)
-
-    value = Column(Float, nullable=False)
 
 
 class DBWibergBondOrderSet(DBBase):
@@ -66,8 +30,7 @@ class DBWibergBondOrderSet(DBBase):
     parent_id = Column(Integer, ForeignKey("conformers.id"), nullable=False)
 
     method = Column(String(10), nullable=False)
-
-    values = relationship("DBWibergBondOrder")
+    values = Column(PickleType, nullable=False)
 
     __table_args__ = (
         UniqueConstraint("parent_id", "method", name="_wbo_parent_method_uc"),
@@ -81,7 +44,7 @@ class DBConformerRecord(DBBase):
     id = Column(Integer, primary_key=True, index=True)
     parent_id = Column(String, ForeignKey("molecules.id"), nullable=False)
 
-    coordinates = relationship("DBCoordinate")
+    coordinates = Column(PickleType, nullable=False)
 
     partial_charges = relationship("DBPartialChargeSet")
     bond_orders = relationship("DBWibergBondOrderSet")
@@ -93,7 +56,7 @@ class DBMoleculeRecord(DBBase):
 
     id = Column(Integer, primary_key=True, index=True)
 
-    hill_formula = Column(String(20), nullable=False)
+    inchi_key = Column(String(20), nullable=False)
     smiles = Column(String, nullable=False)
 
     conformers = relationship("DBConformerRecord")

--- a/nagl/tests/storage/test_storage.py
+++ b/nagl/tests/storage/test_storage.py
@@ -2,8 +2,9 @@ import re
 
 import numpy
 import pytest
+from pydantic import ValidationError
 
-from nagl.storage.db import DB_VERSION, DBConformerRecord, DBCoordinate, DBInformation
+from nagl.storage.db import DB_VERSION, DBConformerRecord, DBInformation
 from nagl.storage.exceptions import IncompatibleDBVersion
 from nagl.storage.storage import (
     ConformerRecord,
@@ -12,6 +13,7 @@ from nagl.storage.storage import (
     PartialChargeSet,
     WibergBondOrderSet,
 )
+from nagl.tests import does_not_raise
 
 
 @pytest.fixture()
@@ -62,226 +64,322 @@ def tmp_molecule_store(tmp_path) -> MoleculeStore:
     return store
 
 
-def test_reorder_record():
-
-    original_coordinates = numpy.arange(6).reshape((2, 3))
-
-    original_record = MoleculeRecord(
-        smiles="[Cl:2][H:1]",
-        conformers=[
-            ConformerRecord(
-                coordinates=original_coordinates,
-                partial_charges=[PartialChargeSet(method="am1", values=[0.5, 1.5])],
-                bond_orders=[WibergBondOrderSet(method="am1", values=[(0, 1, 0.2)])],
-            )
-        ],
-    )
-
-    reordered_record = original_record.reorder("[Cl:1][H:2]")
-    assert reordered_record.smiles == "[Cl:1][H:2]"
-
-    reordered_conformer = reordered_record.conformers[0]
-
-    assert numpy.allclose(
-        reordered_conformer.coordinates, numpy.flipud(original_coordinates)
-    )
-
-    assert numpy.allclose(reordered_conformer.partial_charges[0].values, [1.5, 0.5])
-    assert numpy.allclose(reordered_conformer.bond_orders[0].values, [(1, 0, 0.2)])
+class TestPartialChargeSet:
+    def test_tuple_coercion(self):
+        """Ensure that list types are coerced to immutable tuples"""
+        charge_set = PartialChargeSet(method="am1", values=[0.1])
+        assert isinstance(charge_set.values, tuple)
 
 
-def test_match_conformers():
-
-    matches = MoleculeStore._match_conformers(
-        "[Cl:1][H:2]",
-        db_conformers=[
-            DBConformerRecord(
-                coordinates=[
-                    DBCoordinate(x=-1.0, y=0.0, z=0.0),
-                    DBCoordinate(x=1.0, y=0.0, z=0.0),
-                ]
-            ),
-            DBConformerRecord(
-                coordinates=[
-                    DBCoordinate(x=-2.0, y=0.0, z=0.0),
-                    DBCoordinate(x=2.0, y=0.0, z=0.0),
-                ]
-            ),
-        ],
-        conformers=[
-            ConformerRecord(
-                coordinates=numpy.array([[0.0, -2.0, 0.0], [0.0, 2.0, 0.0]]),
-                partial_charges=[],
-                bond_orders=[],
-            ),
-            ConformerRecord(
-                coordinates=numpy.array([[0.0, -2.0, 0.0], [0.0, 3.0, 0.0]]),
-                partial_charges=[],
-                bond_orders=[],
-            ),
-            ConformerRecord(
-                coordinates=numpy.array([[0.0, 0.0, 0.0], [-2.0, 0.0, 0.0]]),
-                partial_charges=[],
-                bond_orders=[],
-            ),
-        ],
-    )
-
-    assert matches == {0: 1, 2: 0}
-
-
-def test_to_canonical_smiles():
-    assert MoleculeStore._to_canonical_smiles("[Cl:2][H:1]") == "Cl"
-
-
-@pytest.mark.parametrize("smiles, expected", [("[Cl:2][H:1]", "HCl"), ("C", "CH4")])
-def test_to_hill_formula(smiles, expected):
-    assert MoleculeStore._to_hill_formula(smiles) == expected
-
-
-def test_db_version(tmp_path):
-    """Tests that a version is correctly added to a new store."""
-
-    store = MoleculeStore(f"{tmp_path}.sqlite")
-
-    with store._get_session() as db:
-
-        db_info = db.query(DBInformation).first()
-
-        assert db_info is not None
-        assert db_info.version == DB_VERSION
-
-    assert store.db_version == DB_VERSION
-
-
-def test_provenance(tmp_path):
-    """Tests that a stores provenance can be set / retrieved."""
-
-    store = MoleculeStore(f"{tmp_path}.sqlite")
-
-    assert store.general_provenance == {}
-    assert store.software_provenance == {}
-
-    general_provenance = {"author": "Author 1"}
-    software_provenance = {"psi4": "0.1.0"}
-
-    store.set_provenance(general_provenance, software_provenance)
-
-    assert store.general_provenance == general_provenance
-    assert store.software_provenance == software_provenance
-
-
-def test_smiles(tmp_molecule_store):
-    assert {*tmp_molecule_store.smiles} == {"[Ar:1]", "[He:1]", "[Cl:1][Cl:2]"}
-
-
-def charge_methods(tmp_molecule_store):
-    assert {*tmp_molecule_store.charge_methods} == {"am1", "am1bcc"}
-
-
-def wbo_methods(tmp_molecule_store):
-    assert {*tmp_molecule_store.wbo_methods} == {"am1"}
-
-
-def test_db_invalid_version(tmp_path):
-    """Tests that the correct exception is raised when loading a store
-    with an unsupported version."""
-
-    store = MoleculeStore(f"{tmp_path}.sqlite")
-
-    with store._get_session() as db:
-        db_info = db.query(DBInformation).first()
-        db_info.version = DB_VERSION - 1
-
-    with pytest.raises(IncompatibleDBVersion) as error_info:
-        MoleculeStore(f"{tmp_path}.sqlite")
-
-    assert error_info.value.found_version == DB_VERSION - 1
-    assert error_info.value.expected_version == DB_VERSION
-
-
-@pytest.mark.parametrize(
-    "partial_charge_method,bond_order_method,n_expected",
-    [
-        (None, None, 3),
-        ("am1", None, 2),
-        ("am1bcc", None, 2),
-        (None, "am1", 1),
-    ],
-)
-def test_retrieve_data(
-    partial_charge_method, bond_order_method, n_expected, tmp_molecule_store
-):
-
-    retrieved_records = tmp_molecule_store.retrieve(
-        partial_charge_method=partial_charge_method, bond_order_method=bond_order_method
-    )
-    assert len(retrieved_records) == n_expected
-
-    for record in retrieved_records:
-
-        for conformer in record.conformers:
-
-            assert partial_charge_method is None or all(
-                partial_charges.method == partial_charge_method
-                for partial_charges in conformer.partial_charges
-            )
-
-            assert bond_order_method is None or all(
-                bond_orders.method == bond_order_method
-                for bond_orders in conformer.bond_orders
-            )
-
-
-def test_store_partial_charge_data(tmp_path):
-
-    store = MoleculeStore(f"{tmp_path}.sqlite")
-
-    store.store(
-        MoleculeRecord(
-            smiles="[Cl:1][H:2]",
-            conformers=[
-                ConformerRecord(
-                    coordinates=numpy.arange(6).reshape((2, 3)),
-                    partial_charges=[
-                        PartialChargeSet(method="am1", values=[0.50, 1.50])
-                    ],
-                )
+class TestWibergBondOrderSet:
+    def test_tuple_coercion(self):
+        """Ensure that list types are coerced to immutable tuples"""
+        wbo_set = WibergBondOrderSet(
+            method="am1",
+            values=[
+                (0, 1, 0.1),
             ],
         )
-    )
-    assert len(store) == 1
+        assert isinstance(wbo_set.values, tuple)
 
-    store.store(
-        MoleculeRecord(
+
+class TestConformerRecord:
+    def test_partial_charges_by_method(self):
+
+        record = ConformerRecord(
+            coordinates=numpy.ones((4, 3)),
+            partial_charges=[
+                PartialChargeSet(method="am1", values=[0.1, 0.2, 0.3, 0.4]),
+                PartialChargeSet(method="am1bcc", values=[1.0, 2.0, 3.0, 4.0]),
+            ],
+        )
+
+        assert record.partial_charges_by_method == {
+            "am1": (0.1, 0.2, 0.3, 0.4),
+            "am1bcc": (1.0, 2.0, 3.0, 4.0),
+        }
+
+    def test_bond_orders_by_method(self):
+
+        record = ConformerRecord(
+            coordinates=numpy.ones((2, 3)),
+            bond_orders=[WibergBondOrderSet(method="am1", values=[(0, 1, 0.1)])],
+        )
+
+        assert record.bond_orders_by_method == {"am1": ((0, 1, 0.1),)}
+
+    @pytest.mark.parametrize(
+        "value, expected_raises",
+        [
+            (numpy.arange(6), does_not_raise()),
+            (numpy.arange(6).reshape((-1, 3)), does_not_raise()),
+            (
+                numpy.arange(5),
+                pytest.raises(ValidationError, match="coordinates must be re-shapable"),
+            ),
+            (
+                numpy.arange(4).reshape((-1, 2)),
+                pytest.raises(ValidationError, match="coordinates must be re-shapable"),
+            ),
+        ],
+    )
+    def test_validate_coordinates(self, value, expected_raises):
+
+        with expected_raises:
+            record = ConformerRecord(coordinates=value)
+
+            assert isinstance(record.coordinates, numpy.ndarray)
+            assert record.coordinates.flags.writeable is False
+
+    @pytest.mark.parametrize(
+        "value, expected_raises",
+        [
+            (tuple(), does_not_raise()),
+            ((PartialChargeSet(method="am1", values=(0.1, 0.2)),), does_not_raise()),
+            (
+                (
+                    PartialChargeSet(method="am1", values=(0.1, 0.2)),
+                    PartialChargeSet(method="am1", values=(0.1, 0.2)),
+                ),
+                pytest.raises(
+                    ValidationError,
+                    match="multiple charge sets computed using the same method",
+                ),
+            ),
+            (
+                (PartialChargeSet(method="am1", values=(0.1,)),),
+                pytest.raises(
+                    ValidationError, match="the number of partial charges must match"
+                ),
+            ),
+        ],
+    )
+    def test_validate_partial_charges(self, value, expected_raises):
+
+        with expected_raises:
+
+            record = ConformerRecord(
+                coordinates=numpy.ones((2, 3)), partial_charges=value
+            )
+
+            assert isinstance(record.partial_charges, tuple)
+            assert len(record.partial_charges) == len(value)
+
+    @pytest.mark.parametrize(
+        "value, expected_raises",
+        [
+            (tuple(), does_not_raise()),
+            (
+                (WibergBondOrderSet(method="am1", values=((0, 1, 0.1),)),),
+                does_not_raise(),
+            ),
+            (
+                (
+                    WibergBondOrderSet(method="am1", values=((0, 1, 0.1),)),
+                    WibergBondOrderSet(method="am1", values=((0, 1, 0.1),)),
+                ),
+                pytest.raises(
+                    ValidationError,
+                    match="multiple bond order sets computed using the same method",
+                ),
+            ),
+        ],
+    )
+    def test_validate_bond_orders(self, value, expected_raises):
+        with expected_raises:
+            record = ConformerRecord(coordinates=numpy.ones((2, 3)), bond_orders=value)
+
+            assert isinstance(record.bond_orders, tuple)
+            assert len(record.bond_orders) == len(value)
+
+
+class TestMoleculeRecord:
+    def test_average_partial_charges(self):
+
+        record = MoleculeRecord(
+            smiles="[C:1]([H:2])([H:3])([H:4])",
+            conformers=[
+                ConformerRecord(
+                    coordinates=numpy.ones((4, 3)),
+                    partial_charges=[
+                        PartialChargeSet(method="am1", values=[0.1, 0.2, 0.3, 0.4]),
+                    ],
+                ),
+                ConformerRecord(
+                    coordinates=numpy.zeros((4, 3)),
+                    partial_charges=[
+                        PartialChargeSet(method="am1", values=[0.3, 0.4, 0.5, 0.6]),
+                    ],
+                ),
+            ],
+        )
+
+        average_charges = record.average_partial_charges("am1")
+
+        assert isinstance(average_charges, tuple)
+        assert len(average_charges) == 4
+
+        assert numpy.allclose(average_charges, (0.2, 0.3, 0.4, 0.5))
+
+    def test_reorder(self):
+
+        original_coordinates = numpy.arange(6).reshape((2, 3))
+
+        original_record = MoleculeRecord(
             smiles="[Cl:2][H:1]",
             conformers=[
                 ConformerRecord(
-                    coordinates=numpy.flipud(numpy.arange(6).reshape((2, 3))),
-                    partial_charges=[
-                        PartialChargeSet(method="am1bcc", values=[0.25, 0.75])
+                    coordinates=original_coordinates,
+                    partial_charges=[PartialChargeSet(method="am1", values=[0.5, 1.5])],
+                    bond_orders=[
+                        WibergBondOrderSet(method="am1", values=[(0, 1, 0.2)])
                     ],
                 )
             ],
         )
+
+        reordered_record = original_record.reorder("[Cl:1][H:2]")
+        assert reordered_record.smiles == "[Cl:1][H:2]"
+
+        reordered_conformer = reordered_record.conformers[0]
+
+        assert numpy.allclose(
+            reordered_conformer.coordinates, numpy.flipud(original_coordinates)
+        )
+
+        assert numpy.allclose(reordered_conformer.partial_charges[0].values, [1.5, 0.5])
+        assert numpy.allclose(reordered_conformer.bond_orders[0].values, [(1, 0, 0.2)])
+
+
+class TestMoleculeStore:
+    def test_db_version_property(self, tmp_path):
+        """Tests that a version is correctly added to a new store."""
+
+        store = MoleculeStore(f"{tmp_path}.sqlite")
+
+        with store._get_session() as db:
+            db_info = db.query(DBInformation).first()
+
+            assert db_info is not None
+            assert db_info.version == DB_VERSION
+
+        assert store.db_version == DB_VERSION
+
+    def test_provenance_property(self, tmp_path):
+        """Tests that a stores provenance can be set / retrieved."""
+
+        store = MoleculeStore(f"{tmp_path}.sqlite")
+
+        assert store.general_provenance == {}
+        assert store.software_provenance == {}
+
+        general_provenance = {"author": "Author 1"}
+        software_provenance = {"psi4": "0.1.0"}
+
+        store.set_provenance(general_provenance, software_provenance)
+
+        assert store.general_provenance == general_provenance
+        assert store.software_provenance == software_provenance
+
+    def test_smiles_property(self, tmp_molecule_store):
+        assert {*tmp_molecule_store.smiles} == {"[Ar:1]", "[He:1]", "[Cl:1][Cl:2]"}
+
+    def test_charge_methods_property(self, tmp_molecule_store):
+        assert {*tmp_molecule_store.charge_methods} == {"am1", "am1bcc"}
+
+    def test_wbo_methods_property(self, tmp_molecule_store):
+        assert {*tmp_molecule_store.wbo_methods} == {"am1"}
+
+    def test_db_invalid_version(self, tmp_path):
+        """Tests that the correct exception is raised when loading a store
+        with an unsupported version."""
+
+        store = MoleculeStore(f"{tmp_path}.sqlite")
+
+        with store._get_session() as db:
+            db_info = db.query(DBInformation).first()
+            db_info.version = DB_VERSION - 1
+
+        with pytest.raises(IncompatibleDBVersion) as error_info:
+            MoleculeStore(f"{tmp_path}.sqlite")
+
+        assert error_info.value.found_version == DB_VERSION - 1
+        assert error_info.value.expected_version == DB_VERSION
+
+    def test_to_canonical_smiles(self):
+        assert MoleculeStore._to_canonical_smiles("[Cl:2][H:1]") == "Cl"
+
+    @pytest.mark.parametrize(
+        "smiles, expected",
+        [
+            ("Cl", "VEXZGXHMUGYJMC-UHFFFAOYNA-N"),
+            ("[H]Cl", "VEXZGXHMUGYJMC-UHFFFAOYNA-N"),
+            ("[Cl:2][H:1]", "VEXZGXHMUGYJMC-UHFFFAOYNA-N"),
+            ("C", "VNWKTOKETHGBQD-UHFFFAOYNA-N"),
+            ("[CH4]", "VNWKTOKETHGBQD-UHFFFAOYNA-N"),
+        ],
     )
+    def test_to_inchi_key(self, smiles, expected):
+        assert MoleculeStore._to_inchi_key(smiles) == expected
 
-    assert len(store) == 1
-    assert {*store.charge_methods} == {"am1", "am1bcc"}
+    def test_match_conformers(self):
 
-    record = store.retrieve()[0]
-    assert len(record.conformers) == 1
+        matches = MoleculeStore._match_conformers(
+            "[Cl:1][H:2]",
+            db_conformers=[
+                DBConformerRecord(
+                    coordinates=numpy.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+                ),
+                DBConformerRecord(
+                    coordinates=numpy.array([[-2.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+                ),
+            ],
+            conformers=[
+                ConformerRecord(
+                    coordinates=numpy.array([[0.0, -2.0, 0.0], [0.0, 2.0, 0.0]]),
+                    partial_charges=[],
+                    bond_orders=[],
+                ),
+                ConformerRecord(
+                    coordinates=numpy.array([[0.0, -2.0, 0.0], [0.0, 3.0, 0.0]]),
+                    partial_charges=[],
+                    bond_orders=[],
+                ),
+                ConformerRecord(
+                    coordinates=numpy.array([[0.0, 0.0, 0.0], [-2.0, 0.0, 0.0]]),
+                    partial_charges=[],
+                    bond_orders=[],
+                ),
+            ],
+        )
 
-    with pytest.raises(
-        RuntimeError, match=re.escape("am1bcc charges already stored for [Cl:1][H:2]")
-    ):
+        assert matches == {0: 1, 2: 0}
+
+    def test_store_partial_charge_data(self, tmp_path):
+
+        store = MoleculeStore(f"{tmp_path}.sqlite")
+
+        store.store(
+            MoleculeRecord(
+                smiles="[Cl:1][H:2]",
+                conformers=[
+                    ConformerRecord(
+                        coordinates=numpy.arange(6).reshape((2, 3)),
+                        partial_charges=[
+                            PartialChargeSet(method="am1", values=[0.50, 1.50])
+                        ],
+                    )
+                ],
+            )
+        )
+        assert len(store) == 1
 
         store.store(
             MoleculeRecord(
                 smiles="[Cl:2][H:1]",
                 conformers=[
                     ConformerRecord(
-                        coordinates=numpy.arange(6).reshape((2, 3)),
+                        coordinates=numpy.flipud(numpy.arange(6).reshape((2, 3))),
                         partial_charges=[
                             PartialChargeSet(method="am1bcc", values=[0.25, 0.75])
                         ],
@@ -290,38 +388,44 @@ def test_store_partial_charge_data(tmp_path):
             )
         )
 
-    assert len(store) == 1
-    assert {*store.charge_methods} == {"am1", "am1bcc"}
+        assert len(store) == 1
+        assert {*store.charge_methods} == {"am1", "am1bcc"}
 
-    record = store.retrieve()[0]
-    assert len(record.conformers) == 1
+        record = store.retrieve()[0]
+        assert len(record.conformers) == 1
 
+        with pytest.raises(
+            RuntimeError,
+            match=re.escape("am1bcc charges already stored for [Cl:1][H:2]"),
+        ):
 
-def test_store_bond_order_data(tmp_path):
-
-    store = MoleculeStore(f"{tmp_path}.sqlite")
-
-    store.store(
-        MoleculeRecord(
-            smiles="[Cl:1][H:2]",
-            conformers=[
-                ConformerRecord(
-                    coordinates=numpy.arange(6).reshape((2, 3)),
-                    bond_orders=[
-                        WibergBondOrderSet(method="am1", values=[(0, 1, 0.5)])
+            store.store(
+                MoleculeRecord(
+                    smiles="[Cl:2][H:1]",
+                    conformers=[
+                        ConformerRecord(
+                            coordinates=numpy.arange(6).reshape((2, 3)),
+                            partial_charges=[
+                                PartialChargeSet(method="am1bcc", values=[0.25, 0.75])
+                            ],
+                        )
                     ],
                 )
-            ],
-        )
-    )
-    assert len(store) == 1
+            )
 
-    with pytest.raises(
-        RuntimeError, match=re.escape("am1 WBOs already stored for [Cl:1][H:2]")
-    ):
+        assert len(store) == 1
+        assert {*store.charge_methods} == {"am1", "am1bcc"}
+
+        record = store.retrieve()[0]
+        assert len(record.conformers) == 1
+
+    def test_store_bond_order_data(self, tmp_path):
+
+        store = MoleculeStore(f"{tmp_path}.sqlite")
+
         store.store(
             MoleculeRecord(
-                smiles="[Cl:2][H:1]",
+                smiles="[Cl:1][H:2]",
                 conformers=[
                     ConformerRecord(
                         coordinates=numpy.arange(6).reshape((2, 3)),
@@ -332,23 +436,77 @@ def test_store_bond_order_data(tmp_path):
                 ],
             )
         )
+        assert len(store) == 1
 
-    store.store(
-        MoleculeRecord(
-            smiles="[Cl:2][H:1]",
-            conformers=[
-                ConformerRecord(
-                    coordinates=numpy.zeros((2, 3)),
-                    bond_orders=[
-                        WibergBondOrderSet(method="am1", values=[(0, 1, 0.5)])
+        with pytest.raises(
+            RuntimeError, match=re.escape("am1 WBOs already stored for [Cl:1][H:2]")
+        ):
+            store.store(
+                MoleculeRecord(
+                    smiles="[Cl:2][H:1]",
+                    conformers=[
+                        ConformerRecord(
+                            coordinates=numpy.arange(6).reshape((2, 3)),
+                            bond_orders=[
+                                WibergBondOrderSet(method="am1", values=[(0, 1, 0.5)])
+                            ],
+                        )
                     ],
                 )
-            ],
+            )
+
+        store.store(
+            MoleculeRecord(
+                smiles="[Cl:2][H:1]",
+                conformers=[
+                    ConformerRecord(
+                        coordinates=numpy.zeros((2, 3)),
+                        bond_orders=[
+                            WibergBondOrderSet(method="am1", values=[(0, 1, 0.5)])
+                        ],
+                    )
+                ],
+            )
         )
+
+        assert len(store) == 1
+        assert {*store.wbo_methods} == {"am1"}
+
+        record = store.retrieve()[0]
+        assert len(record.conformers) == 2
+
+    @pytest.mark.parametrize(
+        "partial_charge_method,bond_order_method,n_expected",
+        [
+            (None, None, 3),
+            ("am1", None, 2),
+            ("am1bcc", None, 2),
+            (None, "am1", 1),
+        ],
     )
+    def test_retrieve_data(
+        self, partial_charge_method, bond_order_method, n_expected, tmp_molecule_store
+    ):
 
-    assert len(store) == 1
-    assert {*store.wbo_methods} == {"am1"}
+        retrieved_records = tmp_molecule_store.retrieve(
+            partial_charge_method=partial_charge_method,
+            bond_order_method=bond_order_method,
+        )
+        assert len(retrieved_records) == n_expected
 
-    record = store.retrieve()[0]
-    assert len(record.conformers) == 2
+        for record in retrieved_records:
+
+            for conformer in record.conformers:
+
+                assert partial_charge_method is None or all(
+                    partial_charges.method == partial_charge_method
+                    for partial_charges in conformer.partial_charges
+                )
+
+                assert bond_order_method is None or all(
+                    bond_orders.method == bond_order_method
+                    for bond_orders in conformer.bond_orders
+                )
+
+    def test_len(self, tmp_molecule_store):
+        assert len(tmp_molecule_store) == 3


### PR DESCRIPTION
## Description

This PR simplifies the DB store by:

* removing individual tables for coordinates and charge / WBO values and instead just pickling the raw arrays.
* storing the InChI key rather than the hill formula to discriminate identical molecules using.

## Status
- [X] Ready to go