### PR TITLE
Order of magnitudes speed up of conformer comparison

### DIFF
--- a/nagl/cli/label/label.py
+++ b/nagl/cli/label/label.py
@@ -84,7 +84,7 @@ def _label_molecule(smiles: str, guess_stereochemistry: bool) -> MoleculeRecord:
         )
 
     return MoleculeRecord(
-        smiles=molecule.to_smiles(isomeric=False, mapped=True),
+        smiles=molecule.to_smiles(isomeric=True, mapped=True),
         conformers=conformer_records,
     )
 
@@ -222,7 +222,11 @@ def label_cli(
 
     from dask import distributed
 
-    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    root_logger: logging.Logger = logging.getLogger("nagl")
+    root_logger.setLevel(logging.INFO)
+
+    root_handler = logging.StreamHandler()
+    root_handler.setFormatter(logging.Formatter("%(message)s"))
 
     _logger.info("Labeling molecules")
 

--- a/nagl/tests/utilities/test_rmsd.py
+++ b/nagl/tests/utilities/test_rmsd.py
@@ -185,7 +185,7 @@ def test_are_conformers_identical(smiles, conformer_a):
 def test_are_conformers_not_identical():
 
     molecule: Molecule = Molecule.from_mapped_smiles(
-        "[C:1]([H:4])([H:5])([H:6])[C:2]([H:7])([Cl:8])=[O:3]"
+        "[C:1]([H:4])([H:5])([H:6])[C:2]([Cl:7])=[O:3]"
     )
     molecule.generate_conformers(n_conformers=1)
 

--- a/nagl/tests/utilities/test_rmsd.py
+++ b/nagl/tests/utilities/test_rmsd.py
@@ -7,8 +7,9 @@ from openff.toolkit.utils import GLOBAL_TOOLKIT_REGISTRY
 from simtk import unit
 
 from nagl.utilities.rmsd import (
+    _is_conformer_linear,
+    align_conformers,
     are_conformers_identical,
-    compute_best_rmsd,
     compute_rmsd,
 )
 
@@ -51,6 +52,58 @@ def perturb_conformer(conformer: numpy.ndarray, scale: bool):
     ) @ rotation + numpy.random.random()
 
 
+def test_align_conformers():
+
+    # molecule: Molecule = Molecule.from_mapped_smiles("[O:2]=[C:1]([H:3])[H:4]")
+
+    conformer_a = numpy.array(
+        [
+            #          H4
+            #         /
+            # H3 - C1
+            #      ||
+            #      O2
+            [0.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+        ]
+    )
+    conformer_b = numpy.array(
+        [
+            #          H3
+            #         /
+            # H4 - C1
+            #      ||
+            #      O2
+            [0.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+        ]
+    )
+
+    # Rotate and shift the conformers to ensure we aren't just getting lucky.
+    conformer_a = perturb_conformer(conformer_a, scale=False)
+    conformer_b = perturb_conformer(conformer_b, scale=False)
+
+    # Check passing the subset indices that will lead to poor alignment.
+    conformer_a_aligned, conformer_b_aligned = align_conformers(
+        conformer_a, conformer_b, subset_indices_a=[0, 1, 2], subset_indices_b=[0, 1, 2]
+    )
+
+    rmsd = compute_rmsd(conformer_a_aligned, conformer_b_aligned[[0, 1, 3, 2], :])
+    assert not numpy.isclose(rmsd, 0.0)
+
+    # Check passing the subset indices that will lead to perfect alignment.
+    conformer_a_aligned, conformer_b_aligned = align_conformers(
+        conformer_a, conformer_b, subset_indices_a=[0, 1, 2], subset_indices_b=[0, 1, 3]
+    )
+
+    rmsd = compute_rmsd(conformer_a_aligned, conformer_b_aligned[[0, 1, 3, 2], :])
+    assert numpy.isclose(rmsd, 0.0)
+
+
 @pytest.mark.parametrize("scale", [True, False])
 def test_compute_rmsd(scale):
 
@@ -59,7 +112,9 @@ def test_compute_rmsd(scale):
 
     # Generate a random rotation matrix.
     conformer_a = molecule.conformers[0].value_in_unit(unit.angstrom)
-    conformer_b = perturb_conformer(conformer_a, scale)
+    conformer_b = perturb_conformer(conformer_a, scale=scale)
+
+    conformer_a, conformer_b = align_conformers(conformer_a, conformer_b)
 
     rmsd = compute_rmsd(conformer_a, conformer_b)
     rdkit_rmsd = rdkit_compute_best_rmsd(molecule, conformer_a, conformer_b)
@@ -68,81 +123,79 @@ def test_compute_rmsd(scale):
     assert numpy.isclose(rmsd, rdkit_rmsd, atol=1.0e-4)
 
 
-@pytest.mark.parametrize("scale", [True, False])
-def test_compute_best_rmsd(scale):
-
-    molecule: Molecule = Molecule.from_smiles("CO")
-    molecule.generate_conformers(n_conformers=1)
-
-    # Generate a random rotation matrix.
-    conformer_a = molecule.conformers[0].value_in_unit(unit.angstrom)
-    conformer_b = perturb_conformer(conformer_a.copy(), scale)
-
-    # Shuffle the second conformer
-    value = conformer_b[3, :].copy()
-
-    conformer_b[3, :] = conformer_b[2, :]
-    conformer_b[2, :] = value
-
-    rmsd = compute_best_rmsd(molecule, conformer_a, conformer_b)
-    rdkit_rmsd = rdkit_compute_best_rmsd(molecule, conformer_a, conformer_b)
-
-    assert numpy.isclose(rmsd, 0.0) == (not scale)
-    assert numpy.isclose(rmsd, rdkit_rmsd, atol=1.0e-4)
+@pytest.mark.parametrize(
+    "conformer, is_linear",
+    [
+        (numpy.array([[0.0, 0.0, 0.0]]), True),
+        (numpy.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]), True),
+        (numpy.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [2.0, 2.0, 2.0]]), True),
+        (numpy.array([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0], [-2.0, -2.0, -2.0]]), True),
+        (numpy.array([[float(i)] * 3 for i in range(5)]), True),
+        (numpy.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [2.0, 0.0, 0.0]]), False),
+    ],
+)
+def test_is_conformer_linear(conformer, is_linear):
+    assert _is_conformer_linear(conformer) == is_linear
 
 
-@pytest.mark.parametrize("smiles", ["c1ccc(cc1)c2ccccc2", "CCC"])
-def test_are_conformers_identical(smiles):
+@pytest.mark.parametrize(
+    "smiles, conformer_a",
+    [
+        ("c1ccc(cc1)c2ccccc2", None),
+        ("c1ccccc1", None),
+        ("O=C(N)N", None),
+        ("CCC", None),
+        (
+            "CCC",
+            numpy.vstack(
+                [
+                    numpy.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]),
+                    numpy.random.random((8, 3)),
+                ]
+            ),
+        ),
+    ],
+)
+def test_are_conformers_identical(smiles, conformer_a):
 
     molecule: Molecule = Molecule.from_smiles(smiles)
+
+    if conformer_a is None:
+
+        molecule.generate_conformers(n_conformers=1)
+        conformer_a = molecule.conformers[0].value_in_unit(unit.angstrom)
+
+    # Create a permuted version of the conformer, permuting only topology symmetric
+    # atoms.
+    indexed_smiles = molecule.to_smiles(isomeric=False, mapped=True)
+
+    matches = GLOBAL_TOOLKIT_REGISTRY.call(
+        "find_smarts_matches", molecule, indexed_smiles
+    )
+    permuted_indices = next(
+        iter(match for match in matches if match != tuple(range(len(match))))
+    )
+
+    conformer_b = perturb_conformer(conformer_a.copy(), False)[permuted_indices, :]
+
+    assert are_conformers_identical(molecule, conformer_a, conformer_b)
+    assert not are_conformers_identical(molecule, conformer_a, conformer_b * 2.0)
+
+
+def test_are_conformers_not_identical():
+
+    molecule: Molecule = Molecule.from_mapped_smiles(
+        "[C:1]([H:4])([H:5])([H:6])[C:2]([H:7])([Cl:8])=[O:3]"
+    )
     molecule.generate_conformers(n_conformers=1)
 
-    # Create a permuted version of the conformer, permuting only topology symmetric
-    # atoms.
-    indexed_smiles = molecule.to_smiles(isomeric=False, mapped=True)
-
-    matches = GLOBAL_TOOLKIT_REGISTRY.call(
-        "find_smarts_matches", molecule, indexed_smiles
-    )
-    permuted_indices = next(
-        iter(match for match in matches if match != tuple(range(len(matches))))
-    )
-
     conformer_a = molecule.conformers[0].value_in_unit(unit.angstrom)
-    conformer_b = perturb_conformer(conformer_a.copy(), False)[permuted_indices, :]
 
-    assert are_conformers_identical(molecule, conformer_a, conformer_b)
-    assert not are_conformers_identical(molecule, conformer_a, conformer_b * 2.0)
+    # Swap and perturb the hydrogen positions.
+    hydrogen_coordinates = conformer_a[3, :]
 
+    conformer_b = conformer_a.copy()
+    conformer_b[3, :] = conformer_b[4, :]
+    conformer_b[4, :] = hydrogen_coordinates + 0.1
 
-def test_are_conformers_identical_linear():
-    """Tests that ``are_conformers_identical`` performs correctly when all of the
-    heavy atoms are positioned as a linear chain."""
-
-    molecule: Molecule = Molecule.from_smiles("CCC")
-    molecule._conformers = [
-        numpy.vstack(
-            [
-                numpy.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]),
-                numpy.random.random((molecule.n_atoms - 3, 3)),
-            ]
-        )
-        * unit.angstrom
-    ]
-
-    # Create a permuted version of the conformer, permuting only topology symmetric
-    # atoms.
-    indexed_smiles = molecule.to_smiles(isomeric=False, mapped=True)
-
-    matches = GLOBAL_TOOLKIT_REGISTRY.call(
-        "find_smarts_matches", molecule, indexed_smiles
-    )
-    permuted_indices = next(
-        iter(match for match in matches if match != tuple(range(len(matches))))
-    )
-
-    conformer_a = molecule.conformers[0].value_in_unit(unit.angstrom)
-    conformer_b = perturb_conformer(conformer_a.copy(), False)[permuted_indices, :]
-
-    assert are_conformers_identical(molecule, conformer_a, conformer_b)
-    assert not are_conformers_identical(molecule, conformer_a, conformer_b * 2.0)
+    assert not are_conformers_identical(molecule, conformer_a, conformer_b)

--- a/nagl/tests/utilities/test_toolkits.py
+++ b/nagl/tests/utilities/test_toolkits.py
@@ -3,6 +3,7 @@ from openff.toolkit.topology import Molecule
 from openff.utilities import temporary_cd
 
 from nagl.utilities.toolkits import (
+    get_atom_symmetries,
     smiles_to_inchi_key,
     stream_from_file,
     stream_to_file,
@@ -40,3 +41,13 @@ def test_read_write_streams():
 )
 def test_smiles_to_inchi_key(smiles, expected):
     assert smiles_to_inchi_key(smiles) == expected
+
+
+def test_get_atom_symmetries():
+
+    molecule = Molecule.from_mapped_smiles("[H:1][C:2]([H:3])([H:4])[O:5][H:6]")
+
+    atom_symmetries = get_atom_symmetries(molecule)
+
+    assert len({atom_symmetries[i] for i in (0, 2, 3)}) == 1
+    assert len({atom_symmetries[i] for i in (1, 4, 5)}) == 3


### PR DESCRIPTION
## Description

This PR speeds up, by order of magnitudes in certain cases where there is a large number of topologically symmetrical atoms, comparing if two conformers are 'identical' within some tolerance.

This new algorithm makes use of atom symmetries to first try and optimally align the two conformers using a minimum number of atoms, and then performing a simple distance check once aligned. This removes the need to find all possible perturbations of atom ordering when trying to align the molecules.

## Status
- [X] Ready to go