### PR TITLE
Add `DGLMolecule` to device

### DIFF
--- a/nagl/molecules.py
+++ b/nagl/molecules.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, List, Tuple, Type
+import copy
+from typing import TYPE_CHECKING, List, Tuple, Type, TypeVar
 
 import dgl.function
 import torch
@@ -8,6 +9,8 @@ from nagl.utilities.resonance import enumerate_resonance_forms
 
 if TYPE_CHECKING:
     from openff.toolkit.topology import Molecule
+
+_T = TypeVar("_T")
 
 
 def _hetero_to_homo_graph(graph: dgl.DGLHeteroGraph) -> dgl.DGLGraph:
@@ -56,6 +59,13 @@ class _BaseDGLModel:
         """
 
         self._graph = graph
+
+    def to(self: _T, device: str) -> _T:
+
+        return_value = copy.copy(self)
+        return_value._graph = self._graph.to(device)
+
+        return return_value
 
 
 class DGLMolecule(_BaseDGLModel):

--- a/nagl/tests/test_molecules.py
+++ b/nagl/tests/test_molecules.py
@@ -42,6 +42,15 @@ class TestBaseDGLModel:
     def test_atom_features_property(self, dgl_methane):
         assert dgl_methane.atom_features.shape == (5, 4)
 
+    def test_to(self, dgl_methane):
+
+        dgl_methane_to = dgl_methane.to("cpu")
+
+        assert dgl_methane_to != dgl_methane
+        assert dgl_methane_to._graph != dgl_methane._graph  # should be a copy.
+        assert dgl_methane_to.n_atoms == 5
+        assert dgl_methane_to.n_bonds == 4
+
 
 class TestDGLMolecule:
     def test_n_properties(self):


### PR DESCRIPTION
## Description

This PR adds a `to` function to the `DGLMolecule*` classes so that `pytorch-lightning` can correctly move the data batches over to the requested devices.

## Status
- [X] Ready to go