### PR TITLE
Add a general lightning data module

### DIFF
--- a/nagl/lightning.py
+++ b/nagl/lightning.py
@@ -1,18 +1,24 @@
-from typing import Dict, Literal, Tuple, Union
+import errno
+import os.path
+import pickle
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 import pytorch_lightning as pl
 import torch
 import torch.nn.functional
 
+from nagl.datasets import DGLMoleculeDataLoader, DGLMoleculeDataset
+from nagl.features import AtomFeature, BondFeature
 from nagl.molecules import DGLMolecule, DGLMoleculeBatch
 from nagl.nn.modules import ConvolutionModule, ReadoutModule
+from nagl.storage import ChargeMethod, MoleculeStore, WBOMethod
 
 
 def _rmse_loss(y_pred: torch.Tensor, label: torch.Tensor):
     return torch.sqrt(torch.nn.functional.mse_loss(y_pred, label))
 
 
-class MoleculeGCNLightningModel(pl.LightningModule):
+class DGLMoleculeLightningModel(pl.LightningModule):
     """A model which applies a graph convolutional step followed by multiple (labelled)
     pooling and readout steps.
     """
@@ -73,3 +79,167 @@ class MoleculeGCNLightningModel(pl.LightningModule):
     def configure_optimizers(self):
         optimizer = torch.optim.Adam(self.parameters(), lr=self.learning_rate)
         return optimizer
+
+
+class DGLMoleculeDataModule(pl.LightningDataModule):
+    """A utility class that makes loading and featurizing train, validation and test
+    sets more compact."""
+
+    @property
+    def n_atom_features(self) -> Optional[int]:
+        return sum(len(feature) for feature in self._atom_features)
+
+    def __init__(
+        self,
+        atom_features: List[AtomFeature],
+        bond_features: List[BondFeature],
+        partial_charge_method: Optional[ChargeMethod],
+        bond_order_method: Optional[WBOMethod],
+        train_set_path: str,
+        train_batch_size: Optional[int],
+        val_set_path: Optional[str] = None,
+        val_batch_size: Optional[int] = None,
+        test_set_path: Optional[str] = None,
+        test_batch_size: Optional[int] = None,
+        output_path: str = "nagl-data-module.pkl",
+        use_cached_data: bool = False,
+    ):
+        """
+
+        Args:
+            atom_features: The set of atom features to compute for each molecule
+            bond_features: The set of bond features to compute for each molecule
+            partial_charge_method: The (optional) type of partial charges to include
+                in the training labels.
+            bond_order_method: The (optional) type of bond orders to include
+                in the training labels.
+            train_set_path: The (optional) path to the training data stored in a
+                SQLite molecule store. If none is specified no training will
+                be performed.
+            train_batch_size: The training batch size. If none is specified, all the
+                data will be included in a single batch.
+            val_set_path: The (optional) path to the validation data stored in a
+                SQLite molecule store. If none is specified no validation will
+                be performed.
+            val_batch_size: The validation batch size. If none is specified, all the
+                data will be included in a single batch.
+            test_set_path: The (optional) path to the test data stored in a
+                SQLite molecule store. If none is specified no testing will
+                be performed.
+            test_batch_size: The test batch size. If none is specified, all the
+                data will be included in a single batch.
+            output_path: The path to store the PICKLE file to store the prepared data to.
+            use_cached_data: Whether to simply load any data module found at
+                the ``output_path`` rather re-generating it using the other provided
+                arguments. **No validation is done to ensure the loaded data matches
+                the input arguments so be extra careful when using this option**.
+                If this is false and a file is found at ``output_path`` an exception
+                will be raised.
+        """
+        super().__init__()
+
+        self._atom_features = atom_features
+        self._bond_features = bond_features
+
+        self._partial_charge_method = partial_charge_method
+        self._bond_order_method = bond_order_method
+
+        self._train_set_path = train_set_path
+        self._train_batch_size = train_batch_size
+        self._train_data: Optional[DGLMoleculeDataset] = None
+
+        if self._train_set_path is not None:
+
+            self.train_dataloader = lambda: DGLMoleculeDataLoader(
+                self._train_data,
+                batch_size=(
+                    self._train_batch_size
+                    if self._train_batch_size is not None
+                    else len(self._train_data)
+                ),
+            )
+
+        self._val_set_path = val_set_path
+        self._val_batch_size = val_batch_size
+        self._val_data: Optional[DGLMoleculeDataset] = None
+
+        if self._val_set_path is not None:
+
+            self.val_dataloader = lambda: DGLMoleculeDataLoader(
+                self._val_data,
+                batch_size=(
+                    self._val_batch_size
+                    if self._val_batch_size is not None
+                    else len(self._val_data)
+                ),
+            )
+
+        self._test_set_path = test_set_path
+        self._test_batch_size = test_batch_size
+        self._test_data: Optional[DGLMoleculeDataset] = None
+
+        if self._test_set_path is not None:
+
+            self.test_dataloader = lambda: DGLMoleculeDataLoader(
+                self._test_data,
+                batch_size=(
+                    self._test_batch_size
+                    if self._test_batch_size is not None
+                    else len(self._test_data)
+                ),
+            )
+
+        self._output_path = output_path
+        self._use_cached_data = use_cached_data
+
+    def _prepare_data_from_path(self, data_path: str) -> DGLMoleculeDataset:
+
+        extension = os.path.splitext(data_path)[-1].lower()
+
+        if extension == ".sqlite":
+
+            data = DGLMoleculeDataset.from_molecule_stores(
+                MoleculeStore(data_path),
+                partial_charge_method=self._partial_charge_method,
+                bond_order_method=self._bond_order_method,
+                atom_features=self._atom_features,
+                bond_features=self._bond_features,
+            )
+
+            return data
+
+        raise NotImplementedError(
+            f"Only paths to SQLite ``MoleculeStore`` databases are supported, and not "
+            f"'{extension}' files."
+        )
+
+    def prepare_data(self):
+
+        if os.path.isfile(self._output_path):
+
+            if not self._use_cached_data:
+
+                raise FileExistsError(
+                    errno.EEXIST, os.strerror(errno.EEXIST), self._output_path
+                )
+
+            return
+
+        train_data, val_data, test_data = None, None, None
+
+        if self._train_set_path is not None:
+            train_data = self._prepare_data_from_path(self._train_set_path)
+
+        if self._val_set_path is not None:
+            val_data = self._prepare_data_from_path(self._val_set_path)
+
+        if self._test_set_path is not None:
+            test_data = self._prepare_data_from_path(self._test_set_path)
+
+        with open(self._output_path, "wb") as file:
+            pickle.dump((train_data, val_data, test_data), file)
+
+    def setup(self, stage: Optional[str] = None):
+
+        with open(self._output_path, "rb") as file:
+            self._train_data, self._val_data, self._test_data = pickle.load(file)

--- a/nagl/tests/test_features.py
+++ b/nagl/tests/test_features.py
@@ -24,7 +24,10 @@ def test_one_hot_encode():
 
 def test_atomic_element(openff_methane: Molecule):
 
-    encoding = AtomicElement(["H", "C"])(openff_methane).numpy()
+    feature = AtomicElement(["H", "C"])
+    assert len(feature) == 2
+
+    encoding = feature(openff_methane).numpy()
 
     assert encoding.shape == (5, 2)
 
@@ -37,7 +40,10 @@ def test_atomic_element(openff_methane: Molecule):
 
 def test_atom_connectivity(openff_methane: Molecule):
 
-    encoding = AtomConnectivity()(openff_methane).numpy()
+    feature = AtomConnectivity()
+    assert len(feature) == 4
+
+    encoding = feature(openff_methane).numpy()
 
     assert encoding.shape == (5, 4)
 
@@ -49,7 +55,10 @@ def test_atom_formal_charge():
 
     molecule = Molecule.from_smiles("[Cl-]")
 
-    encoding = AtomFormalCharge([0, -1])(molecule).numpy()
+    feature = AtomFormalCharge([0, -1])
+    assert len(feature) == 2
+
+    encoding = feature(molecule).numpy()
     assert encoding.shape == (1, 2)
 
     assert numpy.isclose(encoding[0, 0], 0.0)
@@ -61,7 +70,10 @@ def test_is_aromatic(feature_class):
 
     molecule = Molecule.from_smiles("c1ccccc1")
 
-    encoding = feature_class()(molecule).numpy()
+    feature = feature_class()
+    assert len(feature) == 2
+
+    encoding = feature(molecule).numpy()
     assert encoding.shape == (12, 2)
 
     assert numpy.allclose(encoding[:6, 0], 0.0)
@@ -76,7 +88,10 @@ def test_is_in_ring(feature_class):
 
     molecule = Molecule.from_smiles("c1ccccc1")
 
-    encoding = AtomIsInRing()(molecule).numpy()
+    feature = AtomIsInRing()
+    assert len(feature) == 2
+
+    encoding = feature(molecule).numpy()
     assert encoding.shape == (12, 2)
 
     assert numpy.allclose(encoding[:6, 0], 0.0)
@@ -88,7 +103,10 @@ def test_is_in_ring(feature_class):
 
 def test_bond_order():
 
-    encoding = BondOrder()(Molecule.from_smiles("C=O")).numpy()
+    feature = BondOrder()
+    assert len(feature) == 1
+
+    encoding = feature(Molecule.from_smiles("C=O")).numpy()
     assert encoding.shape == (3, 1)
 
     assert numpy.allclose(encoding, numpy.array([[2.0], [1.0], [1.0]]))
@@ -99,7 +117,10 @@ def test_wiberg_bond_order(openff_methane):
     for i, bond in enumerate(openff_methane.bonds):
         bond.fractional_bond_order = float(i)
 
-    encoding = WibergBondOrder()(openff_methane).numpy()
+    feature = WibergBondOrder()
+    assert len(feature) == 1
+
+    encoding = feature(openff_methane).numpy()
     assert encoding.shape == (4, 1)
 
     assert numpy.allclose(encoding, numpy.arange(4).reshape(-1, 1))

--- a/nagl/tests/test_features.py
+++ b/nagl/tests/test_features.py
@@ -88,7 +88,7 @@ def test_is_in_ring(feature_class):
 
     molecule = Molecule.from_smiles("c1ccccc1")
 
-    feature = AtomIsInRing()
+    feature = feature_class()
     assert len(feature) == 2
 
     encoding = feature(molecule).numpy()

--- a/nagl/tests/test_lightning.py
+++ b/nagl/tests/test_lightning.py
@@ -1,20 +1,32 @@
+import os.path
+import pickle
+
 import numpy
 import pytest
 import torch
 import torch.optim
 
-from nagl.lightning import MoleculeGCNLightningModel
+from nagl.datasets import DGLMoleculeDataset
+from nagl.features import AtomFormalCharge, AtomicElement, BondOrder
+from nagl.lightning import DGLMoleculeDataModule, DGLMoleculeLightningModel
 from nagl.models import ConvolutionModule, ReadoutModule
 from nagl.nn import SequentialLayers
 from nagl.nn.gcn import GCNStack
 from nagl.nn.pooling import PoolAtomFeatures, PoolBondFeatures
 from nagl.nn.postprocess import ComputePartialCharges
+from nagl.storage import (
+    ConformerRecord,
+    MoleculeRecord,
+    MoleculeStore,
+    PartialChargeSet,
+    WibergBondOrderSet,
+)
 
 
 @pytest.fixture()
-def mock_atom_model() -> MoleculeGCNLightningModel:
+def mock_atom_model() -> DGLMoleculeLightningModel:
 
-    return MoleculeGCNLightningModel(
+    return DGLMoleculeLightningModel(
         convolution_module=ConvolutionModule("SAGEConv", in_feats=4, hidden_feats=[4]),
         readout_modules={
             "atom": ReadoutModule(
@@ -27,10 +39,10 @@ def mock_atom_model() -> MoleculeGCNLightningModel:
     )
 
 
-class TestMoleculeGCNLightningModel:
+class TestDGLMoleculeLightningModel:
     def test_init(self):
 
-        model = MoleculeGCNLightningModel(
+        model = DGLMoleculeLightningModel(
             convolution_module=ConvolutionModule(
                 "SAGEConv", in_feats=1, hidden_feats=[2, 2]
             ),
@@ -91,3 +103,150 @@ class TestMoleculeGCNLightningModel:
         optimizer = mock_atom_model.configure_optimizers()
         assert isinstance(optimizer, torch.optim.Adam)
         assert torch.isclose(torch.tensor(optimizer.defaults["lr"]), torch.tensor(0.01))
+
+
+class TestDGLMoleculeDataModule:
+    @pytest.fixture()
+    def mock_data_module(self) -> DGLMoleculeDataModule:
+
+        return DGLMoleculeDataModule(
+            atom_features=[AtomicElement(["C", "H", "Cl"]), AtomFormalCharge([0, 1])],
+            bond_features=[BondOrder()],
+            partial_charge_method="am1bcc",
+            bond_order_method="am1",
+            train_set_path="train.sqlite",
+            train_batch_size=1,
+            val_set_path="val.sqlite",
+            val_batch_size=2,
+            test_set_path="test.sqlite",
+            test_batch_size=3,
+            output_path="tmp.pkl",
+            use_cached_data=True,
+        )
+
+    @pytest.fixture()
+    def mock_data_store(self, tmpdir) -> str:
+        store_path = os.path.join(tmpdir, "store.sqlite")
+
+        store = MoleculeStore(store_path)
+        store.store(
+            MoleculeRecord(
+                smiles="[Cl:1][Cl:2]",
+                conformers=[
+                    ConformerRecord(
+                        coordinates=numpy.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+                        partial_charges=[
+                            PartialChargeSet(method="am1bcc", values=[1.0, -1.0])
+                        ],
+                        bond_orders=[
+                            WibergBondOrderSet(method="am1", values=[(0, 1, 1.0)])
+                        ],
+                    )
+                ],
+            )
+        )
+
+        return store_path
+
+    def test_init(self, mock_data_module):
+
+        assert isinstance(mock_data_module._atom_features[0], AtomicElement)
+        assert mock_data_module.n_atom_features == 5
+
+        assert isinstance(mock_data_module._bond_features[0], BondOrder)
+
+        assert mock_data_module._partial_charge_method == "am1bcc"
+        assert mock_data_module._bond_order_method == "am1"
+
+        assert mock_data_module._train_set_path == "train.sqlite"
+        assert mock_data_module._train_batch_size == 1
+
+        assert mock_data_module._val_set_path == "val.sqlite"
+        assert mock_data_module._val_batch_size == 2
+
+        assert mock_data_module._test_set_path == "test.sqlite"
+        assert mock_data_module._test_batch_size == 3
+
+        assert mock_data_module._output_path == "tmp.pkl"
+        assert mock_data_module._use_cached_data is True
+
+    def test_prepare_data_from_path(self, mock_data_module, mock_data_store):
+
+        dataset = mock_data_module._prepare_data_from_path(mock_data_store)
+
+        assert isinstance(dataset, DGLMoleculeDataset)
+
+        assert dataset.n_features == 5
+        assert len(dataset) == 1
+
+        molecule, labels = next(iter(dataset))
+
+        assert molecule.n_atoms == 2
+        assert molecule.n_bonds == 1
+        assert {*labels} == {"am1bcc-charges", "am1-wbo"}
+
+    def test_prepare_data_from_path_error(self, mock_data_module):
+
+        with pytest.raises(NotImplementedError, match="Only paths to SQLite"):
+            mock_data_module._prepare_data_from_path("tmp.pkl")
+
+    def test_prepare(self, tmpdir, mock_data_store):
+
+        data_module = DGLMoleculeDataModule(
+            atom_features=[AtomicElement(["Cl", "H"])],
+            bond_features=[BondOrder()],
+            partial_charge_method="am1bcc",
+            bond_order_method="am1",
+            train_set_path=mock_data_store,
+            train_batch_size=None,
+            val_set_path=mock_data_store,
+            test_set_path=mock_data_store,
+            output_path=os.path.join(tmpdir, "tmp.pkl"),
+        )
+        data_module.prepare_data()
+
+        assert os.path.isfile(data_module._output_path)
+
+        with open(data_module._output_path, "rb") as file:
+            datasets = pickle.load(file)
+
+        assert all(isinstance(dataset, DGLMoleculeDataset) for dataset in datasets)
+        assert all(dataset.n_features == 2 for dataset in datasets)
+
+    def test_prepare_error(self, tmpdir, mock_data_store):
+
+        data_module = DGLMoleculeDataModule(
+            atom_features=[AtomicElement(["Cl", "H"])],
+            bond_features=[BondOrder()],
+            partial_charge_method="am1bcc",
+            bond_order_method="am1",
+            train_set_path=mock_data_store,
+            train_batch_size=None,
+            output_path=os.path.join(tmpdir, "tmp.pkl"),
+            use_cached_data=False,
+        )
+
+        with open(data_module._output_path, "wb") as file:
+            pickle.dump((None, None, None), file)
+
+        with pytest.raises(FileExistsError):
+            data_module.prepare_data()
+
+    def test_setup(self, tmpdir, mock_data_store):
+
+        data_module = DGLMoleculeDataModule(
+            atom_features=[AtomicElement(["Cl", "H"])],
+            bond_features=[BondOrder()],
+            partial_charge_method="am1bcc",
+            bond_order_method="am1",
+            train_set_path=mock_data_store,
+            train_batch_size=None,
+            output_path=os.path.join(tmpdir, "tmp.pkl"),
+            use_cached_data=False,
+        )
+        data_module.prepare_data()
+        data_module.setup()
+
+        assert isinstance(data_module._train_data, DGLMoleculeDataset)
+        assert data_module._val_data is None
+        assert data_module._test_data is None


### PR DESCRIPTION
## Description

This PR adds a new general `DGLMoleculeDataModule` that tries to make loading in data stored in SQLite molecule stores more compact, e.g.

```
data_module = DGLMoleculeDataModule(
    atom_features,
    bond_features,
    partial_charge_method="am1",
    bond_order_method=None,
    train_set_path="train.sqlite",
    train_batch_size=512,
    val_set_path="val.sqlite",
    test_set_path="test.sqlite",
    use_cached_data=True,
)
n_atom_features = data_module.n_atom_features
```

## Status
- [X] Ready to go