### PR TITLE
Expose resonance enumeration via data module

### DIFF
--- a/nagl/datasets.py
+++ b/nagl/datasets.py
@@ -175,6 +175,7 @@ class DGLMoleculeDataset(Dataset):
         bond_order_method: Optional["WBOMethod"],
         atom_features: List[AtomFeature],
         bond_features: List[BondFeature],
+        enumerate_resonance: bool,
     ) -> "DGLMoleculeDataset":
         """Creates a data set from a specified set of labelled molecule stores.
 
@@ -187,6 +188,9 @@ class DGLMoleculeDataset(Dataset):
                 If ``None``, bonds won't be labelled with WBOs.
             atom_features: The atom features to compute for each molecule.
             bond_features: The bond features to compute for each molecule.
+            enumerate_resonance: Whether to enumerate the lowest energy resonance
+                structures of each molecule and store each within the DGL graph
+                representation.
         """
 
         from openff.toolkit.topology import Molecule
@@ -259,6 +263,7 @@ class DGLMoleculeDataset(Dataset):
                         partial_charge_method=partial_charge_method,
                         bond_order_method=bond_order_method,
                     ),
+                    enumerate_resonance,
                 )
             )
 
@@ -271,7 +276,7 @@ class DGLMoleculeDataset(Dataset):
         atom_features: List[AtomFeature],
         bond_features: List[BondFeature],
         label_function: Callable[["Molecule"], Dict[str, torch.Tensor]],
-        enumerate_resonance: bool = False,
+        enumerate_resonance: bool,
     ) -> DGLMoleculeDatasetEntry:
         """Maps a molecule into a labeled, featurized graph representation.
 

--- a/nagl/lightning.py
+++ b/nagl/lightning.py
@@ -95,6 +95,7 @@ class DGLMoleculeDataModule(pl.LightningDataModule):
         bond_features: List[BondFeature],
         partial_charge_method: Optional[ChargeMethod],
         bond_order_method: Optional[WBOMethod],
+        enumerate_resonance: bool,
         train_set_path: str,
         train_batch_size: Optional[int],
         val_set_path: Optional[str] = None,
@@ -113,6 +114,9 @@ class DGLMoleculeDataModule(pl.LightningDataModule):
                 in the training labels.
             bond_order_method: The (optional) type of bond orders to include
                 in the training labels.
+            enumerate_resonance: Whether to enumerate the lowest energy resonance
+                structures of each molecule and store each within the DGL graph
+                representation.
             train_set_path: The (optional) path to the training data stored in a
                 SQLite molecule store. If none is specified no training will
                 be performed.
@@ -143,6 +147,8 @@ class DGLMoleculeDataModule(pl.LightningDataModule):
 
         self._partial_charge_method = partial_charge_method
         self._bond_order_method = bond_order_method
+
+        self._enumerate_resonance = enumerate_resonance
 
         self._train_set_path = train_set_path
         self._train_batch_size = train_batch_size
@@ -204,6 +210,7 @@ class DGLMoleculeDataModule(pl.LightningDataModule):
                 bond_order_method=self._bond_order_method,
                 atom_features=self._atom_features,
                 bond_features=self._bond_features,
+                enumerate_resonance=self._enumerate_resonance,
             )
 
             return data

--- a/nagl/tests/test_datasets.py
+++ b/nagl/tests/test_datasets.py
@@ -103,7 +103,7 @@ def test_data_set_from_molecule_stores(tmpdir):
     )
 
     data_set = DGLMoleculeDataset.from_molecule_stores(
-        molecule_store, "am1", "am1", [AtomConnectivity()], [BondIsInRing()]
+        molecule_store, "am1", "am1", [AtomConnectivity()], [BondIsInRing()], False
     )
 
     assert len(data_set) == 1

--- a/nagl/tests/test_lightning.py
+++ b/nagl/tests/test_lightning.py
@@ -115,6 +115,7 @@ class TestDGLMoleculeDataModule:
             bond_features=[BondOrder()],
             partial_charge_method="am1bcc",
             bond_order_method="am1",
+            enumerate_resonance=True,
             train_set_path="train.sqlite",
             train_batch_size=1,
             val_set_path="val.sqlite",
@@ -159,6 +160,8 @@ class TestDGLMoleculeDataModule:
         assert mock_data_module._partial_charge_method == "am1bcc"
         assert mock_data_module._bond_order_method == "am1"
 
+        assert mock_data_module._enumerate_resonance is True
+
         assert mock_data_module._train_set_path == "train.sqlite"
         assert mock_data_module._train_batch_size == 1
 
@@ -198,6 +201,7 @@ class TestDGLMoleculeDataModule:
             bond_features=[BondOrder()],
             partial_charge_method="am1bcc",
             bond_order_method="am1",
+            enumerate_resonance=False,
             train_set_path=mock_data_store,
             train_batch_size=None,
             val_set_path=mock_data_store,
@@ -227,6 +231,7 @@ class TestDGLMoleculeDataModule:
             bond_features=[BondOrder()],
             partial_charge_method="am1bcc",
             bond_order_method="am1",
+            enumerate_resonance=False,
             train_set_path=mock_data_store,
             train_batch_size=None,
             output_path=os.path.join(tmpdir, "tmp.pkl"),
@@ -246,6 +251,7 @@ class TestDGLMoleculeDataModule:
             bond_features=[BondOrder()],
             partial_charge_method="am1bcc",
             bond_order_method="am1",
+            enumerate_resonance=False,
             train_set_path=mock_data_store,
             train_batch_size=None,
             output_path=os.path.join(tmpdir, "tmp.pkl"),


### PR DESCRIPTION
## Description

This PR ensures that resonance enumeration is now correctly exposed via the lightning data module constructor.

## Status
- [X] Ready to go