### PR TITLE
Add initial protomer enumeration support

### DIFF
--- a/nagl/cli/prepare/enumerate.py
+++ b/nagl/cli/prepare/enumerate.py
@@ -107,7 +107,7 @@ def _enumerate_tautomers(
     "--protomers/--no-protomers",
     "enumerate_protomers",
     help="Whether to enumerate the possible protontation states or not. "
-    "(required oequacpac)",
+    "(requires oequacpac)",
     default=False,
     show_default=True,
 )

--- a/nagl/tests/cli/prepare/test_enumerate.py
+++ b/nagl/tests/cli/prepare/test_enumerate.py
@@ -17,7 +17,7 @@ def test_enumerate_cli(openff_methane: Molecule, runner):
         writer(buteneol)
         writer(buteneol)
 
-    arguments = ["--input", "molecules.sdf", "--output", "tautomers.sdf"]
+    arguments = ["--input", "molecules.sdf", "--output", "tautomers.sdf", "--tautomers"]
 
     result = runner.invoke(enumerate_cli, arguments)
 


### PR DESCRIPTION
## Description

This PR adds basic protonation state enumeration to the `nagl prepare enumerate` command:

```
nagl prepare enumerate --help                                          
Usage: nagl prepare enumerate [OPTIONS]

  Enumerates all reasonable tautomers (as determine by the OpenEye toolkit)
  of a specified set of molecules.

Options:
  --input FILE                    The path to the input molecules. This should
                                  either be an SDF or a GZipped SDF file.
                                  [required]

  --output FILE                   The path to save the enumerated molecules
                                  to. This should either be an SDF or a
                                  GZipped SDF file.  [required]

  --tautomers / --no-tautomers    Whether to enumerate possible tautomers or
                                  not.  [default: False]

  --max-tautomers INTEGER         The maximum number of tautomers to generate
                                  per input molecule.  [default: 16]

  --protomers / --no-protomers    Whether to enumerate the possible
                                  protontation states or not. (requires
                                  oequacpac)  [default: False]

  --max-protomers INTEGER         The maximum number of protontation states to
                                  generate per input molecule.  [default: 16]

  Parallelization configuration: 
    --n-processes INTEGER         The number of processes to parallelize the
                                  enumeration over.  [default: 1]

  --help                          Show this message and exit.
```

Currently `oequacpac` is required to use this functionality.

## Status
- [X] Ready to go