### PR TITLE
Disable OE molecule normalisation

### DIFF
--- a/examples/train-am1-q-model.py
+++ b/examples/train-am1-q-model.py
@@ -14,6 +14,7 @@ from nagl.nn.modules import ConvolutionModule, ReadoutModule
 from nagl.nn.pooling import PoolAtomFeatures
 from nagl.nn.postprocess import ComputePartialCharges
 from nagl.resonance import enumerate_resonance_forms
+from nagl.utilities.toolkits import normalize_molecule
 
 
 class AtomAverageFormalCharge(AtomFeature):
@@ -21,6 +22,8 @@ class AtomAverageFormalCharge(AtomFeature):
     structures."""
 
     def __call__(self, molecule: Molecule) -> torch.Tensor:
+
+        molecule = normalize_molecule(molecule)
 
         resonance_forms = enumerate_resonance_forms(
             molecule,

--- a/nagl/utilities/toolkits.py
+++ b/nagl/utilities/toolkits.py
@@ -338,8 +338,14 @@ def normalize_molecule(molecule: "Molecule", check_output: bool = True) -> "Mole
         reaction_smarts = [entry["smarts"] for entry in json.load(file)]
 
     try:  # pragma: no cover
-        normal_molecule = _oe_normalize_molecule(molecule, reaction_smarts)
-    except (ImportError, ModuleNotFoundError, ToolkitUnavailableException):
+        # normal_molecule = _oe_normalize_molecule(molecule, reaction_smarts)
+        raise NotImplementedError()
+    except (
+        ImportError,
+        ModuleNotFoundError,
+        ToolkitUnavailableException,
+        NotImplementedError,
+    ):
         normal_molecule = _rd_normalize_molecule(molecule, reaction_smarts)
 
     assert not check_output or Molecule.are_isomorphic(


### PR DESCRIPTION
## Description

This PR disables the OE molecule normalization pathway for now. Currently the `OEUniMolecularRxn` method will only transfer bonds if they are explicitly provided in a SMILES pattern, which means certain single bonds don't have their bond order currectly update. E.g. `[N,P,As,Sb;X3:1](=[O,S,Se,Te:2])=[O,S,Se,Te:3]>>[*+1:1]([*-1:2])=[*:3]` does not explicitly state that the 1-2 bond should have a single bond after the 'reaction'.

Until the SMARTS patterns are re-written this code this path is disabled to avoid confusion and possible valence issues.

## Status
- [X] Ready to go