### PR TITLE
Omit tests in codecov report

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -42,4 +42,4 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-  - covage <6.3  # fix hangs on GH, see coveragepy/issues/1310
+  - coverage <6.3  # fix hangs on GH, see coveragepy/issues/1310

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -42,3 +42,4 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
+  - covage <6.3  # fix hangs on GH, see coveragepy/issues/1310

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,14 @@ exclude_lines =
     raise NotImplementedError
     if __name__ == .__main__.:
     if TYPE_CHECKING:
+omit =
+    # Omit the tests
+    */tests/*
+    # Omit the CLI as codecov does not work well with the multi-processing code.
+    nagl/cli/label/*
+    nagl/cli/prepare/*
+    # Omit generated versioneer
+    nagl/_version.py
 
 [flake8]
 # Flake8, PyFlakes, etc


### PR DESCRIPTION
## Description

It seems that `codecov` has started to include `tests` in the coverage report when it should be omitted. This PR aims to resolve this.

## Status
- [ ] Ready to go