### PR TITLE
Fix store molecules with same InChI but different SMILES

### DIFF
--- a/nagl/storage/db.py
+++ b/nagl/storage/db.py
@@ -56,7 +56,7 @@ class DBMoleculeRecord(DBBase):
 
     id = Column(Integer, primary_key=True, index=True)
 
-    inchi_key = Column(String(20), nullable=False)
+    inchi_key = Column(String(20), nullable=False, index=True)
     smiles = Column(String, nullable=False)
 
     conformers = relationship("DBConformerRecord", cascade="all, delete-orphan")


### PR DESCRIPTION
## Description

This PR fixes a bug whereby trying to store a molecule in different resonance forms (i.e. same InChI key, different SMILES) would lead to exceptions.

## Status
- [ ] Ready to go