### PR TITLE
Allow loss function customisation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Conda Environment
       uses: conda-incubator/setup-miniconda@v2.1.1
       with:
-        python-version: ${{ matrix.cfg.python-version }}
+        python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml
 
         channels: dglteam,conda-forge,defaults

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup Conda Environment
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v2.1.1
       with:
         python-version: ${{ matrix.cfg.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml
@@ -35,6 +35,10 @@ jobs:
         auto-update-conda: true
         auto-activate-base: false
         show-channel-urls: true
+        mamba-version: "*"
+        miniforge-version: latest
+        miniforge-variant: Mambaforge
+        use-mamba: true
 
     - name: Install Package
       shell: bash -l {0}

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -27,15 +27,15 @@ dependencies:
   - pytorch-lightning
 
     # Molecule loading and processing.
-  - openff-toolkit >=0.9.1
+  - openff-toolkit >=0.10.6, <0.11.0
 
     # SQL based molecule storage.
   - sqlalchemy
   - sqlite
 
     # Distributed molecule processing / labelling.
-  - dask <=2.30.1
-  - distributed <=2.30.1
+  - dask =2.30.0
+  - distributed =2.30.0
   - dask-jobqueue
 
     # Testing

--- a/nagl/lightning.py
+++ b/nagl/lightning.py
@@ -38,7 +38,7 @@ class DGLMoleculeLightningModel(pl.LightningModule):
 
         self.convolution_module = convolution_module
         self.readout_modules = torch.nn.ModuleDict(readout_modules)
-        self.loss_function = loss_function
+        self._loss_function = loss_function
 
         self.learning_rate = learning_rate
 
@@ -67,7 +67,7 @@ class DGLMoleculeLightningModel(pl.LightningModule):
         loss = torch.zeros(1).type_as(next(iter(y_pred.values())))
 
         for label_name, label in labels.items():
-            loss += self.loss_function(y_pred[label_name], label)
+            loss += self._loss_function(y_pred[label_name], label)
 
         self.log(f"{step_type}_loss", loss)
         return loss

--- a/nagl/lightning.py
+++ b/nagl/lightning.py
@@ -1,7 +1,7 @@
 import errno
 import os.path
 import pickle
-from typing import Dict, List, Literal, Optional, Tuple, Union
+from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
 
 import pytorch_lightning as pl
 import torch
@@ -14,8 +14,10 @@ from nagl.molecules import DGLMolecule, DGLMoleculeBatch, MoleculeToDGLFunc
 from nagl.nn.modules import ConvolutionModule, ReadoutModule
 from nagl.storage import ChargeMethod, MoleculeStore, WBOMethod
 
+LossFunction = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
-def _rmse_loss(y_pred: torch.Tensor, label: torch.Tensor):
+
+def rmse_loss(y_pred: torch.Tensor, label: torch.Tensor):
     return torch.sqrt(torch.nn.functional.mse_loss(y_pred, label))
 
 
@@ -29,12 +31,14 @@ class DGLMoleculeLightningModel(pl.LightningModule):
         convolution_module: ConvolutionModule,
         readout_modules: Dict[str, ReadoutModule],
         learning_rate: float,
+        loss_function: LossFunction = rmse_loss,
     ):
 
         super().__init__()
 
         self.convolution_module = convolution_module
         self.readout_modules = torch.nn.ModuleDict(readout_modules)
+        self.loss_function = loss_function
 
         self.learning_rate = learning_rate
 
@@ -63,7 +67,7 @@ class DGLMoleculeLightningModel(pl.LightningModule):
         loss = torch.zeros(1).type_as(next(iter(y_pred.values())))
 
         for label_name, label in labels.items():
-            loss += _rmse_loss(y_pred[label_name], label)
+            loss += self.loss_function(y_pred[label_name], label)
 
         self.log(f"{step_type}_loss", loss)
         return loss


### PR DESCRIPTION
## Description
This PR adds an extra loss function argument to the `DGLMoleculeLightningModel` allowing users to provide their own loss function for extra customisation rather than having to implement them all in nagl. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] 

## Questions
- [ ] How would we also include a way to weight the loss function when fitting to properties on different scales. One idea is to add a weights argument to the init which takes a dictionary of the readout label and the corresponding weight factor, however, this means that users would have to enter the labels twice. Ideally they would enter the label the readout and weight in one go somehow. 

## Status
- [x] Ready to go