### PR TITLE
Allow any activation function

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Conda Environment
       uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: ${{ matrix.cfg.python-version }}
+        python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml
 
         channels: dglteam,conda-forge,defaults

--- a/nagl/nn/__init__.py
+++ b/nagl/nn/__init__.py
@@ -1,3 +1,3 @@
-from nagl.nn._nn import ActivationFunction, SequentialLayers
+from nagl.nn._nn import SequentialLayers
 
-__all__ = [ActivationFunction, SequentialLayers]
+__all__ = [SequentialLayers]

--- a/nagl/nn/_nn.py
+++ b/nagl/nn/_nn.py
@@ -1,13 +1,6 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
 
 import torch.nn
-import torch.nn.functional
-from typing_extensions import Literal
-
-if TYPE_CHECKING:
-    ActivationFunction = str
-else:
-    ActivationFunction = Literal["Identity", "Tanh", "ReLU", "LeakyReLU", "ELU"]
 
 
 class SequentialLayers(torch.nn.Sequential):
@@ -19,7 +12,7 @@ class SequentialLayers(torch.nn.Sequential):
         self,
         in_feats: int,
         hidden_feats: List[int],
-        activation: Optional[List[ActivationFunction]] = None,
+        activation: Optional[List[torch.nn.Module]] = None,
         dropout: Optional[List[float]] = None,
     ):
         """
@@ -38,12 +31,9 @@ class SequentialLayers(torch.nn.Sequential):
         n_layers = len(hidden_feats)
 
         # Initialize the default inputs.
-        activation = (
-            [torch.nn.ReLU()] * n_layers
-            if activation is None
-            else [getattr(torch.nn, name)() for name in activation]
-        )
-        dropout = [0.0] * n_layers if dropout is None else dropout
+        activation = activation or [torch.nn.ReLU()] * n_layers
+
+        dropout = dropout or [0.0] * n_layers
 
         # Validate that a consistent number of layers have been specified.
         lengths = [len(hidden_feats), len(activation), len(dropout)]

--- a/nagl/nn/modules.py
+++ b/nagl/nn/modules.py
@@ -4,7 +4,7 @@ import torch
 from typing_extensions import Literal
 
 from nagl.molecules import DGLMolecule, DGLMoleculeBatch
-from nagl.nn import ActivationFunction, SequentialLayers
+from nagl.nn import SequentialLayers
 from nagl.nn.gcn import GCNStack, SAGEConvStack
 from nagl.nn.pooling import PoolingLayer
 from nagl.nn.postprocess import PostprocessLayer
@@ -25,7 +25,7 @@ class ConvolutionModule(torch.nn.Module):
         architecture: GCNArchitecture,
         in_feats: int,
         hidden_feats: List[int],
-        activation: Optional[List[ActivationFunction]] = None,
+        activation: Optional[torch.nn.Module] = None,
         dropout: Optional[List[float]] = None,
     ):
 

--- a/nagl/nn/modules.py
+++ b/nagl/nn/modules.py
@@ -25,7 +25,7 @@ class ConvolutionModule(torch.nn.Module):
         architecture: GCNArchitecture,
         in_feats: int,
         hidden_feats: List[int],
-        activation: Optional[torch.nn.Module] = None,
+        activation: Optional[List[torch.nn.Module]] = None,
         dropout: Optional[List[float]] = None,
     ):
 

--- a/nagl/tests/nn/test_nn.py
+++ b/nagl/tests/nn/test_nn.py
@@ -23,7 +23,7 @@ def test_init_sequential_layers_inputs():
     sequential_layers = SequentialLayers(
         in_feats=1,
         hidden_feats=[2, 1],
-        activation=["ReLU", "LeakyReLU"],
+        activation=[torch.nn.ReLU(), torch.nn.LeakyReLU()],
         dropout=[0.0, 0.5],
     )
 
@@ -47,7 +47,7 @@ def test_init_sequential_layers_invalid():
         SequentialLayers(
             in_feats=1,
             hidden_feats=[2],
-            activation=["ReLU", "LeakyReLU"],
+            activation=[torch.nn.ReLU(), torch.nn.LeakyReLU()],
             dropout=[0.0, 0.5],
         )
 

--- a/nagl/tests/test_lightning.py
+++ b/nagl/tests/test_lightning.py
@@ -60,7 +60,7 @@ class TestDGLMoleculeLightningModel:
                 "atom": ReadoutModule(
                     pooling_layer=PoolAtomFeatures(),
                     readout_layers=SequentialLayers(
-                        in_feats=2, hidden_feats=[2], activation=["Identity"]
+                        in_feats=2, hidden_feats=[2], activation=[torch.nn.Identity()]
                     ),
                     postprocess_layer=ComputePartialCharges(),
                 ),

--- a/nagl/tests/test_models.py
+++ b/nagl/tests/test_models.py
@@ -39,6 +39,13 @@ class TestMoleculeGCNModel:
 
         assert all(x in model.readout_modules for x in ["atom", "bond"])
 
+        # check the activation function in the readout layer
+        assert isinstance(
+            model.readout_modules["atom"].readout_layers[1], torch.nn.Identity
+        )
+        assert isinstance(
+            model.readout_modules["bond"].readout_layers[1], torch.nn.ReLU
+        )
         assert isinstance(model.readout_modules["atom"].pooling_layer, PoolAtomFeatures)
         assert isinstance(model.readout_modules["bond"].pooling_layer, PoolBondFeatures)
 

--- a/nagl/tests/test_models.py
+++ b/nagl/tests/test_models.py
@@ -1,3 +1,5 @@
+import torch.nn
+
 from nagl.models import ConvolutionModule, MoleculeGCNModel, ReadoutModule
 from nagl.nn import SequentialLayers
 from nagl.nn.gcn import GCNStack
@@ -16,7 +18,7 @@ class TestMoleculeGCNModel:
                 "atom": ReadoutModule(
                     pooling_layer=PoolAtomFeatures(),
                     readout_layers=SequentialLayers(
-                        in_feats=2, hidden_feats=[2], activation=["Identity"]
+                        in_feats=2, hidden_feats=[2], activation=[torch.nn.Identity()]
                     ),
                     postprocess_layer=ComputePartialCharges(),
                 ),


### PR DESCRIPTION
## Description
This PR lifts the current restrictions on the activation function allowing it to be any `torch.nn.module` which is an activation function, which should avoid extending the list of available ones in nagl as they are added into pytorch. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Is there some sort of check we could do to ensure the module is an activation function?

## Status
- [ ] Ready to go