### PR TITLE
Support external atom and bond features

### DIFF
--- a/nagl/tests/test_features.py
+++ b/nagl/tests/test_features.py
@@ -1,20 +1,52 @@
+import typing
+
 import numpy
+import pydantic
 import pytest
+import torch
 from openff.toolkit.topology import Molecule
 
 from nagl.features import (
     AtomAverageFormalCharge,
     AtomConnectivity,
+    AtomFeature,
+    AtomFeatureType,
     AtomFormalCharge,
     AtomicElement,
     AtomIsAromatic,
     AtomIsInRing,
+    BondFeature,
+    BondFeatureType,
     BondIsAromatic,
     BondIsInRing,
     BondOrder,
+    CustomAtomFeature,
+    CustomBondFeature,
     WibergBondOrder,
     one_hot_encode,
+    register_atom_feature,
+    register_bond_feature,
 )
+
+
+@pytest.fixture()
+def custom_atom_feature_registry(monkeypatch):
+
+    import nagl.features
+
+    feature_registry = {}
+    monkeypatch.setattr(nagl.features, "_CUSTOM_ATOM_FEATURES", feature_registry)
+    return feature_registry
+
+
+@pytest.fixture()
+def custom_bond_feature_registry(monkeypatch):
+
+    import nagl.features
+
+    feature_registry = {}
+    monkeypatch.setattr(nagl.features, "_CUSTOM_BOND_FEATURES", feature_registry)
+    return feature_registry
 
 
 def test_one_hot_encode():
@@ -80,6 +112,41 @@ def test_atom_average_formal_charge():
     assert numpy.allclose(encoding, expected_encoding)
 
 
+def test_custom_atom_feature(custom_atom_feature_registry):
+    class MyAtomFeature(AtomFeature):
+
+        type: typing.Literal["some-type"] = "some-type"
+
+        def __call__(self, molecule: "Molecule") -> torch.Tensor:
+            return torch.unsqueeze(torch.arange(start=1, end=5), 1)
+
+        def __len__(self):
+            return 4
+
+    register_atom_feature(MyAtomFeature)
+
+    feature = CustomAtomFeature(type="some-type")
+    assert len(feature) == 4
+
+    output = feature(None)
+
+    expected_output = torch.tensor([[1], [2], [3], [4]])
+    assert output.shape == expected_output.shape
+    assert torch.allclose(expected_output, output)
+
+
+def test_discriminate_atom_feature():
+    @pydantic.dataclasses.dataclass
+    class MyConfig:
+        atom_feature: AtomFeatureType
+
+    model_a = MyConfig(atom_feature=AtomicElement())
+    assert isinstance(model_a.atom_feature, AtomicElement)
+
+    model_a = MyConfig(atom_feature=CustomAtomFeature(type="some-type"))
+    assert isinstance(model_a.atom_feature, CustomAtomFeature)
+
+
 @pytest.mark.parametrize("feature_class", [AtomIsAromatic, BondIsAromatic])
 def test_is_aromatic(feature_class):
 
@@ -133,3 +200,88 @@ def test_wiberg_bond_order(openff_methane):
     assert encoding.shape == (4, 1)
 
     assert numpy.allclose(encoding, numpy.arange(4).reshape(-1, 1))
+
+
+def test_custom_bond_feature(custom_bond_feature_registry):
+    class MyBondFeature(BondFeature):
+
+        type: typing.Literal["some-type"] = "some-type"
+
+        def __call__(self, molecule: "Molecule") -> torch.Tensor:
+            return torch.unsqueeze(torch.arange(start=1, end=5), 1)
+
+        def __len__(self):
+            return 4
+
+    register_bond_feature(MyBondFeature)
+
+    feature = CustomBondFeature(type="some-type")
+    assert len(feature) == 4
+
+    output = feature(None)
+
+    expected_output = torch.tensor([[1], [2], [3], [4]])
+    assert output.shape == expected_output.shape
+    assert torch.allclose(expected_output, output)
+
+
+def test_discriminate_bond_feature():
+    @pydantic.dataclasses.dataclass
+    class MyConfig:
+        bond_feature: BondFeatureType
+
+    model_a = MyConfig(bond_feature=BondOrder())
+    assert isinstance(model_a.bond_feature, BondOrder)
+
+    model_a = MyConfig(bond_feature=CustomBondFeature(type="some-type"))
+    assert isinstance(model_a.bond_feature, CustomBondFeature)
+
+
+def test_register_atom_feature(custom_atom_feature_registry):
+    class MyAtomFeature(AtomFeature):
+        type: typing.Literal["some-type"] = "some-type"
+
+    register_atom_feature(MyAtomFeature)
+    assert custom_atom_feature_registry == {"some-type": MyAtomFeature}
+
+
+@pytest.mark.parametrize(
+    "feature_cls, expected_raises",
+    [
+        (str, pytest.raises(TypeError, match="feature should subclass `AtomFeature`")),
+        (AtomFeature, pytest.raises(AttributeError, match="has no `type` attribute.")),
+    ],
+)
+def test_register_atom_feature_raises(
+    feature_cls, expected_raises, custom_atom_feature_registry
+):
+
+    with expected_raises:
+        register_atom_feature(feature_cls)
+
+    assert custom_atom_feature_registry == {}
+
+
+def test_register_bond_feature(custom_bond_feature_registry):
+    class MyBondFeature(BondFeature):
+        type: typing.Literal["some-type"] = "some-type"
+
+    register_bond_feature(MyBondFeature)
+    assert custom_bond_feature_registry == {"some-type": MyBondFeature}
+
+
+@pytest.mark.parametrize(
+    "feature_cls, expected_raises",
+    [
+        (str, pytest.raises(TypeError, match="feature should subclass `BondFeature`")),
+        (BondFeature, pytest.raises(AttributeError, match="has no `type` attribute.")),
+    ],
+)
+def test_register_bond_feature_raises(
+    feature_cls, expected_raises, custom_bond_feature_registry
+):
+
+    with expected_raises:
+        register_bond_feature(feature_cls)
+
+    assert custom_bond_feature_registry == {}


### PR DESCRIPTION
## Description

This PR allows users to register custom features defined outside of NAGL, and have them be useable from the model configuration object.

The API for this looks like:

```python
class MyAtomFeature(AtomFeature):

    type: typing.Literal["some-type"] = "some-type"

    def __call__(self, molecule: "Molecule") -> torch.Tensor:
        return ...

    def __len__(self):
        return ...

register_atom_feature(MyAtomFeature)
```

## Status

- [X] Ready to go