### PR TITLE
Add basic HTML report of predicted atom labels

### DIFF
--- a/devtools/envs/base.yaml
+++ b/devtools/envs/base.yaml
@@ -11,12 +11,15 @@ dependencies:
   - openff-utilities >=0.1.5
   - pydantic
 
+  - rdkit
+
   - click
   - click-option-group
 
   - pytorch
   - dgl >=0.7
 
+  - jinja2
   - tqdm
   - rich
 
@@ -27,7 +30,6 @@ dependencies:
   - pyarrow
     ## Molecule loading and processing.
   - openff-toolkit-base >=0.11.0
-  - rdkit
   - ambertools
 
     # Dev / Testing

--- a/nagl/reporting/__init__.py
+++ b/nagl/reporting/__init__.py
@@ -1,0 +1,3 @@
+from nagl.reporting._reporting import create_atom_label_report
+
+__all__ = ["create_atom_label_report"]

--- a/nagl/reporting/_reporting.py
+++ b/nagl/reporting/_reporting.py
@@ -1,0 +1,139 @@
+import base64
+import pathlib
+import typing
+
+import jinja2
+import torch
+from rdkit import Chem
+from rdkit.Chem import Draw
+
+import nagl.training.metrics
+from nagl.config.data import MetricType
+from nagl.molecules import DGLMolecule
+
+if typing.TYPE_CHECKING:
+    from openff.toolkit import Molecule
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent
+
+
+def _draw_molecule_with_atom_labels(
+    molecule: "Molecule", pred: torch.Tensor, ref: torch.Tensor
+) -> str:
+    """Renders two molecules with per atom labels as an SVG image - one showing
+    predicted labels and another showing reference ones.
+    """
+
+    pred_molecule: Chem = molecule.to_rdkit()
+
+    for atom, label in zip(pred_molecule.GetAtoms(), pred.detach().numpy()):
+        atom.SetProp("atomNote", str(f"{label:.3f}"))
+
+    Draw.PrepareMolForDrawing(pred_molecule)
+
+    ref_molecule: Chem = molecule.to_rdkit()
+
+    for atom, label in zip(ref_molecule.GetAtoms(), ref.detach().numpy()):
+        atom.SetProp("atomNote", str(f"{label:.3f}"))
+
+    Draw.PrepareMolForDrawing(ref_molecule)
+
+    draw_options = Draw.MolDrawOptions()
+    draw_options.legendFontSize = 25
+
+    image = Draw.MolsToGridImage(
+        [pred_molecule, ref_molecule],
+        legends=["prediction", "reference"],
+        molsPerRow=2,
+        subImgSize=(400, 400),
+        useSVG=True,
+        drawOptions=draw_options,
+    )
+    return image
+
+
+def _generate_per_atom_jinja_dicts(
+    entries: typing.List[typing.Tuple["Molecule", torch.Tensor, torch.Tensor]],
+    metrics: typing.List[MetricType],
+):
+
+    metrics_funcs = {
+        metric: nagl.training.metrics.get_metric(metric) for metric in metrics
+    }
+
+    return_value = []
+
+    for molecule, per_atom_pred, per_atom_ref in entries:
+
+        if isinstance(molecule, DGLMolecule):
+            molecule = molecule.to_openff()
+
+        image = _draw_molecule_with_atom_labels(molecule, per_atom_pred, per_atom_ref)
+
+        image_encoded = base64.b64encode(image.encode()).decode()
+        image_src = f"data:image/svg+xml;base64,{image_encoded}"
+
+        entry_metrics = {
+            metric.upper(): f"{metrics_func(per_atom_pred, per_atom_ref):.4f}"
+            for metric, metrics_func in metrics_funcs.items()
+        }
+        return_value.append({"img": image_src, "metrics": entry_metrics})
+
+    return return_value
+
+
+def create_atom_label_report(
+    entries: typing.List[typing.Tuple["Molecule", torch.Tensor, torch.Tensor]],
+    metrics: typing.List[MetricType],
+    rank_by: MetricType,
+    output_path: pathlib.Path,
+    top_n_entries: int = 100,
+    bottom_n_entries: int = 100,
+):
+    """Creates a simple HTML report that shows the values of predicted and reference
+    labels for the top N and bottom M entries in the specified list.
+
+    Args:
+        entries: The list of molecules to consider for the report. Each entry should be
+            a tuple of the form ``(molecule, per_atom_pred, per_atom_ref)``. Here
+            ``per_atom_pred`` should be a tensor with ``shape=(n_atoms)`` and contain
+            predictions by a model, and ``per_atom_ref`` the same but containg the
+            reference labels.
+        metrics: The metrics to compute for each entry.
+        rank_by: The metric to rank the entries by.
+        output_path: The path to save the report to.
+        top_n_entries: The number of highest ranking entries to show according to
+            ``rank_by``.
+        bottom_n_entries: The number of lowest ranking entries to show according to
+            ``rank_by``.
+    """
+
+    entries_and_ranks = []
+
+    rank_by_func = nagl.training.metrics.get_metric(rank_by)
+
+    for entry in entries:
+
+        molecule, per_atom_pred, per_atom_ref = entry
+
+        metric = rank_by_func(per_atom_pred, per_atom_ref)
+        entries_and_ranks.append((entry, metric))
+
+    entries_and_ranks = sorted(entries_and_ranks, key=lambda x: x[1], reverse=True)
+
+    top_n_structures = _generate_per_atom_jinja_dicts(
+        [x for x, _ in entries_and_ranks[:top_n_entries]], metrics
+    )
+    bottom_n_structures = _generate_per_atom_jinja_dicts(
+        [x for x, _ in entries_and_ranks[-bottom_n_entries:]], metrics
+    )
+
+    template_loader = jinja2.FileSystemLoader(searchpath=_TEMPLATE_DIR)
+    template_env = jinja2.Environment(loader=template_loader)
+
+    template = template_env.get_template("template.html")
+    rendered = template.render(
+        top_n_structures=top_n_structures, bottom_n_structures=bottom_n_structures
+    )
+
+    output_path.write_text(rendered)

--- a/nagl/reporting/template.html
+++ b/nagl/reporting/template.html
@@ -1,11 +1,12 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Bootstrap demo</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
-    <style>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Bootstrap demo</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
+  <style>
       #root {
           padding: 1rem;
           display: flex;
@@ -13,110 +14,124 @@
           gap: 1rem;
           justify-content: space-between;
       }
+
       .preview-modal {
-        display: none;
-        position: fixed;
-        z-index: 1;
-        left: 0;
-        top: 0;
-        width: 100%;
-        height: 100%;
-        background-color: rgba(0,0,0,0.2); /* Black w/ opacity */
+          display: none;
+          position: fixed;
+          z-index: 1;
+          left: 0;
+          top: 0;
+          width: 100%;
+          height: 100%;
+          background-color: rgba(0, 0, 0, 0.2); /* Black w/ opacity */
       }
+
       .preview-modal-content {
-        display: block;
-        margin: 0 auto;
-        position: relative;
-        top: 50%;
-        transform: translateY(-50%);
-        height: 90%;
-        max-width: 90%;
+          display: block;
+          margin: 0 auto;
+          position: relative;
+          top: 50%;
+          transform: translateY(-50%);
+          height: 90%;
+          max-width: 90%;
       }
+
       .thumbnail {
           cursor: pointer;
       }
-    </style>
-  </head>
-  <body>
 
-    <div id="root">
+      .collapsable-header {
+          transform: rotate(0);
+      }
+  </style>
+</head>
+<body>
 
-      <div class="card">
-        <div class="card-header">
-          <a class="btn" data-bs-toggle="collapse" href="#collapseTopN">
-            Top {{ top_n_structures|length }} Structures
-          </a>
-        </div>
-        <div id="collapseTopN" class="collapse show">
-          <div class="card-body">
-            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5">
-{% for item in top_n_structures %}
-              <div class="col mb-4">
-                <div class="card">
-                  <img src="{{ item.img }}" class="card-img-top thumbnail" alt="thumbnail">
-                  <div class="card-body">
-                    <ul class="list-unstyled">
-{% for key, value in item.metrics.items() %}
-                      <li><b>{{ key }}:</b> {{ value }}</li>
-{% endfor %}
-                    </ul>
-                  </div>
-                </div>
+<div id="root">
+
+  <div class="card">
+    <div class="card-header collapsable-header">
+      <a class="btn stretched-link" data-bs-toggle="collapse" href="#collapseTopN">
+        Top {{ top_n_structures|length }} Structures
+      </a>
+    </div>
+    <div id="collapseTopN" class="collapse show">
+      <div class="card-body">
+        <div class="row row-cols-1 row-cols-sm-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-4">
+          {% for item in top_n_structures %}
+          <div class="col mb-4">
+            <div class="card">
+              <img src="{{ item.img }}" class="card-img-top thumbnail" alt="thumbnail">
+              <div class="card-body">
+                <ul class="list-unstyled">
+                  {% for key, value in item.metrics.items() %}
+                  <li><b>{{ key }}:</b> {{ value }}</li>
+                  {% endfor %}
+                </ul>
               </div>
-{% endfor %}
             </div>
           </div>
-        </div>
-      </div>
-
-      <div class="card">
-        <div class="card-header">
-          <a class="btn" data-bs-toggle="collapse" href="#collapseBottomN">
-            Bottom {{ bottom_n_structures|length }} Structures
-          </a>
-        </div>
-        <div id="collapseBottomN" class="collapse show">
-          <div class="card-body">
-            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5">
-{% for item in bottom_n_structures %}
-              <div class="col mb-4">
-                <div class="card">
-                  <img src="{{ item.img }}" class="card-img-top thumbnail" alt="thumbnail">
-                  <div class="card-body">
-                    <ul class="list-unstyled">
-{% for key, value in item.metrics.items() %}
-                      <li><b>{{ key }}:</b> {{ value }}</li>
-{% endfor %}
-                    </ul>
-                  </div>
-                </div>
-              </div>
-{% endfor %}
-            </div>
-          </div>
+          {% endfor %}
         </div>
       </div>
     </div>
+  </div>
 
-    <div id="modal-root" class="preview-modal">
-      <img class="preview-modal-content" id="modal-img" alt="">
+  <div class="card">
+    <div class="card-header collapsable-header">
+      <a class="btn stretched-link" data-bs-toggle="collapse" href="#collapseBottomN">
+        Bottom {{ bottom_n_structures|length }} Structures
+      </a>
     </div>
-    <script>
-      const modal = document.getElementById("modal-root");
-      const modalImg = document.getElementById("modal-img");
-      modalImg.addEventListener('click', (e) => {
+    <div id="collapseBottomN" class="collapse show">
+      <div class="card-body">
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5">
+          {% for item in bottom_n_structures %}
+          <div class="col mb-4">
+            <div class="card">
+              <img src="{{ item.img }}" class="card-img-top thumbnail" alt="thumbnail">
+              <div class="card-body">
+                <ul class="list-unstyled">
+                  {% for key, value in item.metrics.items() %}
+                  <li><b>{{ key }}:</b> {{ value }}</li>
+                  {% endfor %}
+                </ul>
+              </div>
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="modal-root" class="preview-modal">
+  <img class="preview-modal-content" id="modal-img" alt="">
+</div>
+<script>
+    const modal = document.getElementById("modal-root");
+    const modalImg = document.getElementById("modal-img");
+    modalImg.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         e.stopImmediatePropagation();
         return false;
-      });
-      modal.addEventListener('click', () => {
-          modal.style.display = "none";
-      });
-      document.querySelectorAll(".thumbnail").forEach(
-          img => {img.onclick = function(){modal.style.display = "block"; modalImg.src = this.src;}}
-      )
-    </script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN" crossorigin="anonymous"></script>
-  </body>
+    });
+    modal.addEventListener('click', () => {
+        modal.style.display = "none";
+    });
+    document.querySelectorAll(".thumbnail").forEach(
+        img => {
+            img.onclick = function () {
+                modal.style.display = "block";
+                modalImg.src = this.src;
+            }
+        }
+    )
+</script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
+        crossorigin="anonymous"></script>
+</body>
 </html>

--- a/nagl/reporting/template.html
+++ b/nagl/reporting/template.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Bootstrap demo</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
+    <style>
+      #root {
+          padding: 1rem;
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+          justify-content: space-between;
+      }
+      .preview-modal {
+        display: none;
+        position: fixed;
+        z-index: 1;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0,0,0,0.2); /* Black w/ opacity */
+      }
+      .preview-modal-content {
+        display: block;
+        margin: 0 auto;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        height: 90%;
+        max-width: 90%;
+      }
+      .thumbnail {
+          cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+
+    <div id="root">
+
+      <div class="card">
+        <div class="card-header">
+          <a class="btn" data-bs-toggle="collapse" href="#collapseTopN">
+            Top {{ top_n_structures|length }} Structures
+          </a>
+        </div>
+        <div id="collapseTopN" class="collapse show">
+          <div class="card-body">
+            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5">
+{% for item in top_n_structures %}
+              <div class="col mb-4">
+                <div class="card">
+                  <img src="{{ item.img }}" class="card-img-top thumbnail" alt="thumbnail">
+                  <div class="card-body">
+                    <ul class="list-unstyled">
+{% for key, value in item.metrics.items() %}
+                      <li><b>{{ key }}:</b> {{ value }}</li>
+{% endfor %}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+{% endfor %}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <a class="btn" data-bs-toggle="collapse" href="#collapseBottomN">
+            Bottom {{ bottom_n_structures|length }} Structures
+          </a>
+        </div>
+        <div id="collapseBottomN" class="collapse show">
+          <div class="card-body">
+            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5">
+{% for item in bottom_n_structures %}
+              <div class="col mb-4">
+                <div class="card">
+                  <img src="{{ item.img }}" class="card-img-top thumbnail" alt="thumbnail">
+                  <div class="card-body">
+                    <ul class="list-unstyled">
+{% for key, value in item.metrics.items() %}
+                      <li><b>{{ key }}:</b> {{ value }}</li>
+{% endfor %}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+{% endfor %}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div id="modal-root" class="preview-modal">
+      <img class="preview-modal-content" id="modal-img" alt="">
+    </div>
+    <script>
+      const modal = document.getElementById("modal-root");
+      const modalImg = document.getElementById("modal-img");
+      modalImg.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        return false;
+      });
+      modal.addEventListener('click', () => {
+          modal.style.display = "none";
+      });
+      document.querySelectorAll(".thumbnail").forEach(
+          img => {img.onclick = function(){modal.style.display = "block"; modalImg.src = this.src;}}
+      )
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/nagl/tests/reporting/test_reporting.py
+++ b/nagl/tests/reporting/test_reporting.py
@@ -22,11 +22,11 @@ def test_draw_molecule_with_atom_labels():
 def test_generate_per_atom_jinja_dicts():
 
     entries = [
-        (Molecule.from_smiles("[H]CL"), torch.zeros(2), torch.zeros(2)),
+        (Molecule.from_smiles("[H]Cl"), torch.zeros(2), torch.zeros(2)),
         (DGLMolecule.from_smiles("[H]Br", [], []), torch.zeros(2), torch.zeros(2)),
     ]
 
-    jinja_dicts = _generate_per_atom_jinja_dicts(entries, ["rmse"])
+    jinja_dicts = _generate_per_atom_jinja_dicts(entries, ["rmse"], True, 1.0)
     assert len(jinja_dicts) == 2
 
     assert all("img" in item for item in jinja_dicts)

--- a/nagl/tests/reporting/test_reporting.py
+++ b/nagl/tests/reporting/test_reporting.py
@@ -1,0 +1,52 @@
+import torch
+from openff.toolkit import Molecule
+
+from nagl.molecules import DGLMolecule
+from nagl.reporting._reporting import (
+    _draw_molecule_with_atom_labels,
+    _generate_per_atom_jinja_dicts,
+    create_atom_label_report,
+)
+
+
+def test_draw_molecule_with_atom_labels():
+
+    molecule = Molecule.from_smiles("[Cl-]")
+
+    svg = _draw_molecule_with_atom_labels(
+        molecule, torch.tensor([9.87]), torch.tensor([1.23])
+    )
+    assert "svg" in svg
+
+
+def test_generate_per_atom_jinja_dicts():
+
+    entries = [
+        (Molecule.from_smiles("[H]CL"), torch.zeros(2), torch.zeros(2)),
+        (DGLMolecule.from_smiles("[H]Br", [], []), torch.zeros(2), torch.zeros(2)),
+    ]
+
+    jinja_dicts = _generate_per_atom_jinja_dicts(entries, ["rmse"])
+    assert len(jinja_dicts) == 2
+
+    assert all("img" in item for item in jinja_dicts)
+    assert all("metrics" in item for item in jinja_dicts)
+    assert all("RMSE" in item["metrics"] for item in jinja_dicts)
+
+
+def test_create_atom_label_report(tmp_cwd):
+
+    entries = [
+        (Molecule.from_smiles("[H]Cl"), torch.zeros(2), torch.ones(2)),
+        (Molecule.from_smiles("[H]Br"), torch.zeros(2), torch.zeros(2)),
+        (Molecule.from_smiles("[H]O[H]"), torch.zeros(3), torch.zeros(3)),
+    ]
+
+    report_path = tmp_cwd / "report.html"
+
+    create_atom_label_report(entries, ["rmse"], "rmse", report_path, 2, 1)
+    assert report_path.is_file()
+
+    report_contents = report_path.read_text()
+    assert "Top 2 Structures" in report_contents
+    assert "Bottom 1 Structures" in report_contents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,4 @@ namespaces = true
 where = ["."]
 
 [tool.setuptools.package-data]
-"nagl" = ["data/**/*"]
+"nagl" = ["reporting/template.html"]


### PR DESCRIPTION
## Description

This PR adds a simple HTML report that shows predicted vs reference atom labels as well as computed metrics for a list of molecules.

Clicking on any of the images will open a pop-up with a larger, easier to read, image.

<img width="600" alt="Screenshot 2023-01-25 at 21 14 02" src="https://user-images.githubusercontent.com/22272126/214742835-f9c6657d-b690-4582-a448-819925bbf3b2.png">

## Status
- [X] Ready to go