### PR TITLE
Fix lightning data module batch size and performance

### DIFF
--- a/nagl/datasets.py
+++ b/nagl/datasets.py
@@ -320,7 +320,7 @@ def collate_dgl_molecules(
     ]
 ) -> typing.Tuple[DGLMoleculeBatch, typing.Dict[str, torch.Tensor]]:
 
-    if isinstance(entries[0], dgl.DGLGraph):
+    if isinstance(entries[0], (dgl.DGLGraph, DGLMolecule)):
         entries = [entries]
 
     molecules, labels = zip(*entries)

--- a/nagl/reporting/_reporting.py
+++ b/nagl/reporting/_reporting.py
@@ -32,7 +32,7 @@ def _draw_molecule_with_atom_labels(
 
     if highlight_outliers:
 
-        delta_sq = torch.abs(pred - ref)
+        delta_sq = torch.abs(pred.squeeze() - ref.squeeze())
 
         delta_mean = delta_sq.mean()
         delta_std = delta_sq.std()
@@ -44,7 +44,7 @@ def _draw_molecule_with_atom_labels(
     pred_molecule: Chem = molecule.to_rdkit()
 
     for atom, label in zip(pred_molecule.GetAtoms(), pred.detach().numpy()):
-        atom.SetProp("atomNote", str(f"{label:.3f}"))
+        atom.SetProp("atomNote", str(f"{float(label):.3f}"))
 
     Draw.PrepareMolForDrawing(pred_molecule)
 

--- a/nagl/training/lightning.py
+++ b/nagl/training/lightning.py
@@ -198,11 +198,17 @@ class DGLMoleculeDataModule(pl.LightningDataModule):
 
             target_data = self._data_sets[stage]
 
+            batch_size = (
+                len(target_data)
+                if dataset_config.batch_size is None
+                else dataset_config.batch_size
+            )
+
             return DataLoader(
                 dataset=target_data,
-                batch_size=dataset_config.batch_size,
+                batch_size=batch_size,
                 shuffle=False,
-                num_workers=1,
+                num_workers=0,
                 collate_fn=collate_dgl_molecules,
             )
 
@@ -239,10 +245,7 @@ class DGLMoleculeDataModule(pl.LightningDataModule):
         if self._cache_dir is None:
             return
 
-        stages = [stage] if stage is not None else [*self._data_set_paths]
-        stages = [stage for stage in stages if self._data_set_paths[stage] is not None]
-
-        for stage in stages:
+        for stage in self._data_set_paths:
 
             self._data_sets[stage] = DGLMoleculeDataset.from_featurized(
                 self._cache_dir / f"{stage}.parquet", columns=None


### PR DESCRIPTION
## Description

This PR ensures the correct batch size is passed to the data loader if ``None``, and turns off multiple workers which significantly slowed performance.

## Status
- [X] Ready to go