### PR TITLE
Dipole reshape

### DIFF
--- a/nagl/training/loss.py
+++ b/nagl/training/loss.py
@@ -164,7 +164,8 @@ class DipoleTarget(_BaseTarget):
         prediction: typing.Dict[str, torch.Tensor],
     ) -> torch.Tensor:
         metric_func = get_metric(self.metric)
-        target_dipole = labels[self.dipole_column].squeeze()
+        # reshape as it can be flat
+        target_dipole = torch.reshape(labels[self.dipole_column], (-1, 3))
         n_atoms_per_molecule = (
             (molecules.n_atoms,)
             if isinstance(molecules, DGLMolecule)


### PR DESCRIPTION
## Description
Following #62 I missed the reshaping of the target dipole to make the arrays the same shape for the loss calculation, this removes the pytorch warning in the testing logs about the arrays not having the same shape. 

## Status
- [X] Ready to go